### PR TITLE
Add session context config args

### DIFF
--- a/datafusion/tests/test_context.py
+++ b/datafusion/tests/test_context.py
@@ -21,21 +21,23 @@ import pyarrow.dataset as ds
 from datafusion import column, literal, SessionContext
 import pytest
 
+
 def test_create_context_no_args():
     SessionContext()
 
+
 def test_create_context_with_all_valid_args():
     ctx = SessionContext(
-            target_partitions=1,
-            default_catalog="foo",
-            default_schema="bar",
-            create_default_catalog_and_schema=True,
-            information_schema=True,
-            repartition_joins=False,
-            repartition_aggregations=False,
-            repartition_windows=False,
-            parquet_pruning=False
-            )
+        target_partitions=1,
+        default_catalog="foo",
+        default_schema="bar",
+        create_default_catalog_and_schema=True,
+        information_schema=True,
+        repartition_joins=False,
+        repartition_aggregations=False,
+        repartition_windows=False,
+        parquet_pruning=False,
+    )
 
     # verify that at least some of the arguments worked
     ctx.catalog("foo").database("bar")

--- a/datafusion/tests/test_context.py
+++ b/datafusion/tests/test_context.py
@@ -18,7 +18,29 @@
 import pyarrow as pa
 import pyarrow.dataset as ds
 
-from datafusion import column, literal
+from datafusion import column, literal, SessionContext
+import pytest
+
+def test_create_context_no_args():
+    SessionContext()
+
+def test_create_context_with_all_valid_args():
+    ctx = SessionContext(
+            target_partitions=1,
+            default_catalog="foo",
+            default_schema="bar",
+            create_default_catalog_and_schema=True,
+            information_schema=True,
+            repartition_joins=False,
+            repartition_aggregations=False,
+            repartition_windows=False,
+            parquet_pruning=False
+            )
+
+    # verify that at least some of the arguments worked
+    ctx.catalog("foo").database("bar")
+    with pytest.raises(KeyError):
+        ctx.catalog("datafusion")
 
 
 def test_register_record_batches(ctx):

--- a/src/context.rs
+++ b/src/context.rs
@@ -27,7 +27,7 @@ use datafusion::arrow::datatypes::Schema;
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::datasource::datasource::TableProvider;
 use datafusion::datasource::MemTable;
-use datafusion::execution::context::SessionContext;
+use datafusion::execution::context::{SessionContext,SessionConfig};
 use datafusion::prelude::{CsvReadOptions, ParquetReadOptions};
 
 use crate::catalog::{PyCatalog, PyTable};
@@ -45,13 +45,50 @@ pub(crate) struct PySessionContext {
     ctx: SessionContext,
 }
 
+
 #[pymethods]
 impl PySessionContext {
-    // TODO(kszucs): should expose the configuration options as keyword arguments
+    #[allow(clippy::too_many_arguments)]
+    #[args(
+        default_catalog = "\"datafusion\"",
+        default_schema = "\"public\"",
+        create_default_catalog_and_schema = "true",
+        information_schema = "false",
+        repartition_joins = "true",
+        repartition_aggregations = "true",
+        repartition_windows = "true",
+        parquet_pruning = "true",
+        target_partitions = "None"
+    )]
     #[new]
-    fn new() -> Self {
+    fn new(
+        default_catalog: &str,
+        default_schema: &str,
+        create_default_catalog_and_schema: bool,
+        information_schema: bool,
+        repartition_joins: bool,
+        repartition_aggregations: bool,
+        repartition_windows: bool,
+        parquet_pruning: bool,
+        target_partitions: Option<usize>,
+        // TODO: config_options
+        ) -> Self {
+        let cfg = SessionConfig::new()
+            .create_default_catalog_and_schema(create_default_catalog_and_schema)
+            .with_default_catalog_and_schema(default_catalog, default_schema)
+            .with_information_schema(information_schema)
+            .with_repartition_joins(repartition_joins)
+            .with_repartition_aggregations(repartition_aggregations)
+            .with_repartition_windows(repartition_windows)
+            .with_parquet_pruning(parquet_pruning);
+
+        let cfg_full = match target_partitions {
+            None => cfg,
+            Some(x) => cfg.with_target_partitions(x),
+        };
+
         PySessionContext {
-            ctx: SessionContext::new(),
+            ctx: SessionContext::with_config(cfg_full),
         }
     }
 
@@ -213,4 +250,6 @@ impl PySessionContext {
     fn empty_table(&self) -> PyResult<PyDataFrame> {
         Ok(PyDataFrame::new(self.ctx.read_empty()?))
     }
+
 }
+

--- a/src/context.rs
+++ b/src/context.rs
@@ -27,7 +27,7 @@ use datafusion::arrow::datatypes::Schema;
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::datasource::datasource::TableProvider;
 use datafusion::datasource::MemTable;
-use datafusion::execution::context::{SessionContext,SessionConfig};
+use datafusion::execution::context::{SessionConfig, SessionContext};
 use datafusion::prelude::{CsvReadOptions, ParquetReadOptions};
 
 use crate::catalog::{PyCatalog, PyTable};
@@ -44,7 +44,6 @@ use crate::utils::wait_for_future;
 pub(crate) struct PySessionContext {
     ctx: SessionContext,
 }
-
 
 #[pymethods]
 impl PySessionContext {
@@ -72,7 +71,7 @@ impl PySessionContext {
         parquet_pruning: bool,
         target_partitions: Option<usize>,
         // TODO: config_options
-        ) -> Self {
+    ) -> Self {
         let cfg = SessionConfig::new()
             .create_default_catalog_and_schema(create_default_catalog_and_schema)
             .with_default_catalog_and_schema(default_catalog, default_schema)
@@ -250,6 +249,4 @@ impl PySessionContext {
     fn empty_table(&self) -> PyResult<PyDataFrame> {
         Ok(PyDataFrame::new(self.ctx.read_empty()?))
     }
-
 }
-


### PR DESCRIPTION
Allows passing SessionContext configuration via keyword arguments, as suggested by a TODO comment. I wasn't sure how to deal with `config_options` so I left it out. The unit test also only verifies the `database` and `schema` arguments as I don't think there's currently a way to read the config from Python.