### PR TITLE
[DataFrame] - Add intersect and except bindings for DataFrame

### DIFF
--- a/datafusion/tests/test_dataframe.py
+++ b/datafusion/tests/test_dataframe.py
@@ -277,12 +277,19 @@ def test_intersect():
         [pa.array([3]), pa.array([6])],
         names=["a", "b"],
     )
-    df_c = ctx.create_dataframe([[batch]]).sort(column("a").sort(ascending=True))
+    df_c = ctx.create_dataframe([[batch]]).sort(
+        column("a").sort(ascending=True)
+    )
 
     df_c.show()
     df_a.intersect(df_b).sort(column("a").sort(ascending=True)).show()
 
-    assert df_c.collect() == df_a.intersect(df_b).sort(column("a").sort(ascending=True)).collect()
+    assert (
+        df_c.collect()
+        == df_a.intersect(df_b)
+        .sort(column("a").sort(ascending=True))
+        .collect()
+    )
 
 
 def test_except_all():
@@ -304,6 +311,13 @@ def test_except_all():
         [pa.array([1, 2]), pa.array([4, 5])],
         names=["a", "b"],
     )
-    df_c = ctx.create_dataframe([[batch]]).sort(column("a").sort(ascending=True))
+    df_c = ctx.create_dataframe([[batch]]).sort(
+        column("a").sort(ascending=True)
+    )
 
-    assert df_c.collect() == df_a.except_all(df_b).sort(column("a").sort(ascending=True)).collect()
+    assert (
+        df_c.collect()
+        == df_a.except_all(df_b)
+        .sort(column("a").sort(ascending=True))
+        .collect()
+    )

--- a/datafusion/tests/test_dataframe.py
+++ b/datafusion/tests/test_dataframe.py
@@ -256,3 +256,54 @@ def test_repartition(df):
 
 def test_repartition_by_hash(df):
     df.repartition_by_hash(column("a"), num=2)
+
+
+def test_intersect():
+    ctx = SessionContext()
+
+    batch = pa.RecordBatch.from_arrays(
+        [pa.array([1, 2, 3]), pa.array([4, 5, 6])],
+        names=["a", "b"],
+    )
+    df_a = ctx.create_dataframe([[batch]])
+
+    batch = pa.RecordBatch.from_arrays(
+        [pa.array([3, 4, 5]), pa.array([6, 7, 8])],
+        names=["a", "b"],
+    )
+    df_b = ctx.create_dataframe([[batch]])
+
+    batch = pa.RecordBatch.from_arrays(
+        [pa.array([3]), pa.array([6])],
+        names=["a", "b"],
+    )
+    df_c = ctx.create_dataframe([[batch]]).sort(column("a").sort(ascending=True))
+
+    df_c.show()
+    df_a.intersect(df_b).sort(column("a").sort(ascending=True)).show()
+
+    assert df_c.collect() == df_a.intersect(df_b).sort(column("a").sort(ascending=True)).collect()
+
+
+def test_except_all():
+    ctx = SessionContext()
+
+    batch = pa.RecordBatch.from_arrays(
+        [pa.array([1, 2, 3]), pa.array([4, 5, 6])],
+        names=["a", "b"],
+    )
+    df_a = ctx.create_dataframe([[batch]])
+
+    batch = pa.RecordBatch.from_arrays(
+        [pa.array([3, 4, 5]), pa.array([6, 7, 8])],
+        names=["a", "b"],
+    )
+    df_b = ctx.create_dataframe([[batch]])
+
+    batch = pa.RecordBatch.from_arrays(
+        [pa.array([1, 2]), pa.array([4, 5])],
+        names=["a", "b"],
+    )
+    df_c = ctx.create_dataframe([[batch]]).sort(column("a").sort(ascending=True))
+
+    assert df_c.collect() == df_a.except_all(df_b).sort(column("a").sort(ascending=True)).collect()

--- a/datafusion/tests/test_dataframe.py
+++ b/datafusion/tests/test_dataframe.py
@@ -281,15 +281,9 @@ def test_intersect():
         column("a").sort(ascending=True)
     )
 
-    df_c.show()
-    df_a.intersect(df_b).sort(column("a").sort(ascending=True)).show()
+    df_a_i_b = df_a.intersect(df_b).sort(column("a").sort(ascending=True))
 
-    assert (
-        df_c.collect()
-        == df_a.intersect(df_b)
-        .sort(column("a").sort(ascending=True))
-        .collect()
-    )
+    assert df_c.collect() == df_a_i_b.collect()
 
 
 def test_except_all():
@@ -315,9 +309,6 @@ def test_except_all():
         column("a").sort(ascending=True)
     )
 
-    assert (
-        df_c.collect()
-        == df_a.except_all(df_b)
-        .sort(column("a").sort(ascending=True))
-        .collect()
-    )
+    df_a_e_b = df_a.except_all(df_b).sort(column("a").sort(ascending=True))
+
+    assert df_c.collect() == df_a_e_b.collect()

--- a/src/dataframe.rs
+++ b/src/dataframe.rs
@@ -192,4 +192,16 @@ impl PyDataFrame {
         let new_df = self.df.repartition(Partitioning::Hash(expr, num))?;
         Ok(Self::new(new_df))
     }
+
+    /// Calculate the intersection of two `DataFrame`s.  The two `DataFrame`s must have exactly the same schema
+    fn intersect(&self, py_df: PyDataFrame) -> PyResult<Self> {
+        let new_df = self.df.intersect(py_df.df)?;
+        Ok(Self::new(new_df))
+    }
+
+    /// Calculate the exception of two `DataFrame`s.  The two `DataFrame`s must have exactly the same schema
+    fn except_all(&self, py_df: PyDataFrame) -> PyResult<Self> {
+        let new_df = self.df.except(py_df.df)?;
+        Ok(Self::new(new_df))
+    }
 }


### PR DESCRIPTION
Close #27 

`except` is a keyword in Python and cannot be used as a function name, I replaced it with `except_all` like [PySpark `except_All`](https://github.com/apache/spark/blob/d4c58159925133771d305cc7ac4f1248f215812c/python/pyspark/sql/dataframe.py#L487-L513).

