### PR TITLE
allow config options to be passed to context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -664,6 +664,7 @@ dependencies = [
  "futures",
  "mimalloc",
  "object_store",
+ "parking_lot",
  "pyo3",
  "rand 0.7.3",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ mimalloc = { version = "*", optional = true, default-features = false }
 async-trait = "0.1"
 futures = "0.3"
 object_store = { version = "0.5.1", features = ["aws", "gcp", "azure"] }
+parking_lot = "0.12"
 
 [lib]
 name = "datafusion_python"

--- a/datafusion/tests/test_context.py
+++ b/datafusion/tests/test_context.py
@@ -39,7 +39,7 @@ def test_create_context_with_all_valid_args():
         repartition_aggregations=False,
         repartition_windows=False,
         parquet_pruning=False,
-        config_options = { "foo": "bar" }
+        config_options=None,
     )
 
     # verify that at least some of the arguments worked

--- a/datafusion/tests/test_context.py
+++ b/datafusion/tests/test_context.py
@@ -39,6 +39,7 @@ def test_create_context_with_all_valid_args():
         repartition_aggregations=False,
         repartition_windows=False,
         parquet_pruning=False,
+        config_options = { "foo": "bar" }
     )
 
     # verify that at least some of the arguments worked

--- a/src/context.rs
+++ b/src/context.rs
@@ -81,7 +81,7 @@ impl PySessionContext {
         target_partitions: Option<usize>,
         config_options: Option<HashMap<String, String>>,
     ) -> Self {
-        let mut options = ConfigOptions::new();
+        let mut options = ConfigOptions::from_env();
         if let Some(hash_map) = config_options {
             for (k, v) in &hash_map {
                 if let Ok(v) = v.parse::<bool>() {

--- a/src/context.rs
+++ b/src/context.rs
@@ -43,7 +43,6 @@ use datafusion::datasource::datasource::TableProvider;
 use datafusion::datasource::MemTable;
 use datafusion::execution::context::{SessionConfig, SessionContext};
 use datafusion::prelude::{AvroReadOptions, CsvReadOptions, NdJsonReadOptions, ParquetReadOptions};
-use datafusion_common::ScalarValue;
 
 /// `PySessionContext` is able to plan and execute DataFusion plans.
 /// It has a powerful optimizer, a physical planner for local execution, and a
@@ -85,11 +84,11 @@ impl PySessionContext {
         if let Some(hash_map) = config_options {
             for (k, v) in &hash_map {
                 if let Ok(v) = v.parse::<bool>() {
-                    options.set(k, ScalarValue::Boolean(Some(v)));
+                    options.set_bool(k, v);
                 } else if let Ok(v) = v.parse::<u64>() {
-                    options.set(k, ScalarValue::UInt64(Some(v)));
+                    options.set_u64(k, v);
                 } else {
-                    options.set(k, ScalarValue::Utf8(Some(v.to_owned())));
+                    options.set_string(k, v);
                 }
             }
         }

--- a/src/context.rs
+++ b/src/context.rs
@@ -95,8 +95,6 @@ impl PySessionContext {
         }
         let config_options = Arc::new(RwLock::new(options));
 
-        println!("config_options = {:?}", config_options);
-
         let mut cfg = SessionConfig::new()
             .create_default_catalog_and_schema(create_default_catalog_and_schema)
             .with_default_catalog_and_schema(default_catalog, default_schema)


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

I want to be able to configure the context.

```python
config_options = {
    "datafusion.execution.parquet.enable_page_index": "true",
    "datafusion.execution.parquet.pushdown_filters": "true",
    "datafusion.execution.parquet.reorder_filters": "true",
}

ctx = datafusion.SessionContext(config_options = config_options)
```

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

SessionContext::new() has a new argument for config options dict / hash map

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->