### PR TITLE
Build for manylinux 2014

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,7 +106,7 @@ jobs:
           docker run --rm -v $(pwd):/io \
             --workdir /io \
             ghcr.io/pyo3/maturin:v0.14.2 \
-            build --release --manylinux 2010 --locked
+            build --release --manylinux 2014 --locked
       - name: Archive wheels
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
As agreed at https://github.com/apache/arrow-datafusion-python/pull/85 the version of manylinux is bumped from 2010 to 2014

Reason: Maturin 0.14.+ does not support manylinux 2010 anymore

# Which issue does this PR close?

Related to #84 .

 # Rationale for this change

Maturin 0.14.0 and newer does not support manylinux 2010

# What changes are included in this PR?


# Are there any user-facing changes?

Some older versions of Python are not supported anymore.