### PR TITLE
Add a workflow that builds the docs and deploys them at staged or production

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,7 +1,7 @@
 on:
   push:
     branches:
-      - docs-workflow
+      - master
     tags-ignore:
       - "**-rc**"
 
@@ -16,7 +16,7 @@ jobs:
         id: target-branch
         run: |
           set -x
-          if test '${{ github.ref }}' = 'refs/heads/docs-workflow'; then
+          if test '${{ github.ref }}' = 'refs/heads/master'; then
             echo "value=asf-staging" >> $GITHUB_OUTPUT
           elif test '${{ github.ref_type }}' = 'tag'; then
             echo "value=asf-site" >> $GITHUB_OUTPUT


### PR DESCRIPTION
# Which issue does this PR close?

Closes #39.

 # Rationale for this change

Publish the documentation for the Datafusion Python bindings.

* When changes are pushed  to `master` then it will copy the generated HTMLs to `asf-staging` branch and update https://arrow.staged.apache.org/datafusion-python, i.e. the staging site. See https://github.com/apache/arrow-datafusion-python/pull/104#issuecomment-1338271363

* When changes are pushed  to a non-RC tag, e.g. `0.8.0`, then it will copy the generated HTMLs to `asf-site` branch and update https://arrow.apache.org/datafusion-python, i.e. the production site. See #105 


# What changes are included in this PR?

A new GitHub Actions workflow is introduced that builds the docs and deploys them at the appropriate site

# Are there any user-facing changes?

No API changes!
