### PR TITLE
Issue #39 - Add .asf.yaml for asf-site

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -20,7 +20,6 @@ notifications:
   issues_status: issues@arrow.apache.org
   issues_comment: github@arrow.apache.org
   pullrequests: github@arrow.apache.org
-  jira_options: link label worklog
 github:
   description: "Apache Arrow DataFusion Python Bindings"
   homepage: https://arrow.apache.org/datafusion-python/

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -17,7 +17,8 @@
 
 notifications:
   commits:      commits@arrow.apache.org
-  issues:       github@arrow.apache.org
+  issues_status: issues@arrow.apache.org
+  issues_comment: github@arrow.apache.org
   pullrequests: github@arrow.apache.org
   jira_options: link label worklog
 github:

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -23,7 +23,7 @@ notifications:
   jira_options: link label worklog
 github:
   description: "Apache Arrow DataFusion Python Bindings"
-  homepage: https://arrow.apache.org/datafusion
+  homepage: https://arrow.apache.org/datafusion-python/
   enabled_merge_buttons:
     squash: true
     merge: false

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,0 +1,34 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+notifications:
+  commits:      commits@arrow.apache.org
+  issues:       github@arrow.apache.org
+  pullrequests: github@arrow.apache.org
+  jira_options: link label worklog
+github:
+  description: "Apache Arrow DataFusion Python Bindings"
+  homepage: https://arrow.apache.org/datafusion
+  enabled_merge_buttons:
+    squash: true
+    merge: false
+    rebase: false
+  features:
+    issues: true
+publish:
+  whoami: asf-site
+  subdir: datafusion-python


### PR DESCRIPTION
# Which issue does this PR close?

Issue #39 .

 # Rationale for this change

To auto-update the documentation whenever something is pushed to the `asf-site` branch.

# What changes are included in this PR?

Adds `publish` section in `.asf.yaml` so that it publishes to https://arrow.apache.org/datafusion-python

# Are there any user-facing changes?

No