### PR TITLE
Add entries for publishing production (asf-site) and staging docs

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -29,3 +29,11 @@ github:
     rebase: false
   features:
     issues: true
+
+staging:
+  whoami: asf-staging
+  subdir: datafusion-python
+  
+publish:
+  whoami: asf-site
+  subdir: datafusion-python


### PR DESCRIPTION

# Which issue does this PR close?

Related to #39 .

 # Rationale for this change

Add entries to .asf.yaml for publishing the docs for asf-site and asf-staging.
See https://github.com/apache/arrow-datafusion-python/pull/104#discussion_r1041493094

# What changes are included in this PR?

Infra stuff

# Are there any user-facing changes?

No