### PR TITLE
test: Expand tests for built-in functions

### DIFF
--- a/datafusion/tests/test_functions.py
+++ b/datafusion/tests/test_functions.py
@@ -91,6 +91,16 @@ def test_math_functions():
         f.log2(col_v + literal(pa.scalar(1))),
         f.log10(col_v + literal(pa.scalar(1))),
         f.random(),
+        f.atan(col_v),
+        f.atan2(col_v, literal(pa.scalar(1.1))),
+        f.ceil(col_v),
+        f.floor(col_v),
+        f.power(col_v, literal(pa.scalar(3))),
+        f.pow(col_v, literal(pa.scalar(4))),
+        f.round(col_v),
+        f.sqrt(col_v),
+        f.signum(col_v),
+        f.trunc(col_v),
     )
     batches = df.collect()
     assert len(batches) == 1
@@ -113,6 +123,16 @@ def test_math_functions():
         result.column(9), np.log10(values + 1.0)
     )
     np.testing.assert_array_less(result.column(10), np.ones_like(values))
+    np.testing.assert_array_almost_equal(result.column(11), np.arctan(values))
+    np.testing.assert_array_almost_equal(result.column(12), np.arctan2(values, 1.1))
+    np.testing.assert_array_almost_equal(result.column(13), np.ceil(values))
+    np.testing.assert_array_almost_equal(result.column(14), np.floor(values))
+    np.testing.assert_array_almost_equal(result.column(15), np.power(values, 3))
+    np.testing.assert_array_almost_equal(result.column(16), np.power(values, 4))
+    np.testing.assert_array_almost_equal(result.column(17), np.round(values))
+    np.testing.assert_array_almost_equal(result.column(18), np.sqrt(values))
+    np.testing.assert_array_almost_equal(result.column(19), np.sign(values))
+    np.testing.assert_array_almost_equal(result.column(20), np.trunc(values))
 
 
 def test_string_functions(df):

--- a/datafusion/tests/test_functions.py
+++ b/datafusion/tests/test_functions.py
@@ -212,9 +212,15 @@ def test_string_functions(df):
 def test_hash_functions(df):
     exprs = [
         f.digest(column("a"), literal(m))
-        for m in ("md5", "sha256", "sha512", "blake2s", "blake3")
+        for m in ("md5", "sha224", "sha256", "sha384", "sha512", "blake2s", "blake3")
     ]
-    df = df.select(*exprs)
+    df = df.select(
+        *exprs,
+        f.sha224(column("a")),
+        f.sha256(column("a")),
+        f.sha384(column("a")),
+        f.sha512(column("a")),
+    )
     result = df.collect()
     assert len(result) == 1
     result = result[0]
@@ -227,6 +233,22 @@ def test_hash_functions(df):
         ]
     )
     assert result.column(1) == pa.array(
+        [
+            b(
+                "4149DA18AA8BFC2B1E382C6C2655"
+                "6D01A92C261B6436DAD5E3BE3FCC"
+            ),
+            b(
+                "12972632B6D3B6AA52BD6434552F"
+                "08C1303D56B817119406466E9236"
+            ),
+            b(
+                "6641A7E8278BCD49E476E7ACAE15"
+                "8F4105B2952D22AEB2E0B9A231A0"
+            ),
+        ]
+    )
+    assert result.column(2) == pa.array(
         [
             b(
                 "185F8DB32271FE25F561A6FC938B2E26"
@@ -242,7 +264,26 @@ def test_hash_functions(df):
             ),
         ]
     )
-    assert result.column(2) == pa.array(
+    assert result.column(3) == pa.array(
+        [
+            b(
+                "3519FE5AD2C596EFE3E276A6F351B8FC"
+                "0B03DB861782490D45F7598EBD0AB5FD"
+                "5520ED102F38C4A5EC834E98668035FC"
+            ),
+            b(
+                "ED7CED84875773603AF90402E42C65F3"
+                "B48A5E77F84ADC7A19E8F3E8D3101010"
+                "22F552AEC70E9E1087B225930C1D260A"
+            ),
+            b(
+                "1D0EC8C84EE9521E21F06774DE232367"
+                "B64DE628474CB5B2E372B699A1F55AE3"
+                "35CC37193EF823E33324DFD9A70738A6"
+            ),
+        ]
+    )
+    assert result.column(4) == pa.array(
         [
             b(
                 "3615F80C9D293ED7402687F94B22D58E"
@@ -264,7 +305,7 @@ def test_hash_functions(df):
             ),
         ]
     )
-    assert result.column(3) == pa.array(
+    assert result.column(5) == pa.array(
         [
             b(
                 "F73A5FBF881F89B814871F46E26AD3FA"
@@ -280,7 +321,7 @@ def test_hash_functions(df):
             ),
         ]
     )
-    assert result.column(4) == pa.array(
+    assert result.column(6) == pa.array(
         [
             b(
                 "FBC2B0516EE8744D293B980779178A35"
@@ -296,3 +337,7 @@ def test_hash_functions(df):
             ),
         ]
     )
+    assert result.column(7) == result.column(1)     # SHA-224
+    assert result.column(8) == result.column(2)     # SHA-256
+    assert result.column(9) == result.column(3)    # SHA-384
+    assert result.column(10) == result.column(4)    # SHA-512

--- a/datafusion/tests/test_functions.py
+++ b/datafusion/tests/test_functions.py
@@ -34,7 +34,13 @@ def df():
             pa.array(["Hello", "World", "!"]),
             pa.array([4, 5, 6]),
             pa.array(["hello ", " world ", " !"]),
-            pa.array([datetime(2022, 12, 31), datetime(2027, 6, 26), datetime(2020, 7, 2)])
+            pa.array(
+                [
+                    datetime(2022, 12, 31),
+                    datetime(2027, 6, 26),
+                    datetime(2020, 7, 2),
+                ]
+            ),
         ],
         names=["a", "b", "c", "d"],
     )
@@ -130,11 +136,17 @@ def test_math_functions():
     )
     np.testing.assert_array_less(result.column(10), np.ones_like(values))
     np.testing.assert_array_almost_equal(result.column(11), np.arctan(values))
-    np.testing.assert_array_almost_equal(result.column(12), np.arctan2(values, 1.1))
+    np.testing.assert_array_almost_equal(
+        result.column(12), np.arctan2(values, 1.1)
+    )
     np.testing.assert_array_almost_equal(result.column(13), np.ceil(values))
     np.testing.assert_array_almost_equal(result.column(14), np.floor(values))
-    np.testing.assert_array_almost_equal(result.column(15), np.power(values, 3))
-    np.testing.assert_array_almost_equal(result.column(16), np.power(values, 4))
+    np.testing.assert_array_almost_equal(
+        result.column(15), np.power(values, 3)
+    )
+    np.testing.assert_array_almost_equal(
+        result.column(16), np.power(values, 4)
+    )
     np.testing.assert_array_almost_equal(result.column(17), np.round(values))
     np.testing.assert_array_almost_equal(result.column(18), np.sqrt(values))
     np.testing.assert_array_almost_equal(result.column(19), np.sign(values))
@@ -175,7 +187,9 @@ def test_string_functions(df):
     result = df.collect()
     assert len(result) == 1
     result = result[0]
-    assert result.column(0) == pa.array([72, 87, 33], type=pa.int32())  # H = 72; W = 87; ! = 33
+    assert result.column(0) == pa.array(
+        [72, 87, 33], type=pa.int32()
+    )  # H = 72; W = 87; ! = 33
     assert result.column(1) == pa.array([40, 40, 8], type=pa.int32())
     assert result.column(2) == pa.array(["World", "World", "World"])
     assert result.column(3) == pa.array([5, 5, 1], type=pa.int32())
@@ -214,7 +228,15 @@ def test_string_functions(df):
 def test_hash_functions(df):
     exprs = [
         f.digest(column("a"), literal(m))
-        for m in ("md5", "sha224", "sha256", "sha384", "sha512", "blake2s", "blake3")
+        for m in (
+            "md5",
+            "sha224",
+            "sha256",
+            "sha384",
+            "sha512",
+            "blake2s",
+            "blake3",
+        )
     ]
     df = df.select(
         *exprs,
@@ -236,18 +258,9 @@ def test_hash_functions(df):
     )
     assert result.column(1) == pa.array(
         [
-            b(
-                "4149DA18AA8BFC2B1E382C6C2655"
-                "6D01A92C261B6436DAD5E3BE3FCC"
-            ),
-            b(
-                "12972632B6D3B6AA52BD6434552F"
-                "08C1303D56B817119406466E9236"
-            ),
-            b(
-                "6641A7E8278BCD49E476E7ACAE15"
-                "8F4105B2952D22AEB2E0B9A231A0"
-            ),
+            b("4149DA18AA8BFC2B1E382C6C26556D01A92C261B6436DAD5E3BE3FCC"),
+            b("12972632B6D3B6AA52BD6434552F08C1303D56B817119406466E9236"),
+            b("6641A7E8278BCD49E476E7ACAE158F4105B2952D22AEB2E0B9A231A0"),
         ]
     )
     assert result.column(2) == pa.array(
@@ -339,10 +352,10 @@ def test_hash_functions(df):
             ),
         ]
     )
-    assert result.column(7) == result.column(1)     # SHA-224
-    assert result.column(8) == result.column(2)     # SHA-256
-    assert result.column(9) == result.column(3)    # SHA-384
-    assert result.column(10) == result.column(4)    # SHA-512
+    assert result.column(7) == result.column(1)  # SHA-224
+    assert result.column(8) == result.column(2)  # SHA-256
+    assert result.column(9) == result.column(3)  # SHA-384
+    assert result.column(10) == result.column(4)  # SHA-512
 
 
 def test_temporal_functions(df):
@@ -350,23 +363,38 @@ def test_temporal_functions(df):
         f.date_part(literal("month"), column("d")),
         f.datepart(literal("year"), column("d")),
         f.date_trunc(literal("month"), column("d")),
-        f.date_trunc(literal("day"), column("d")),
+        f.datetrunc(literal("day"), column("d")),
         f.from_unixtime(literal(1673383974)),
         f.to_timestamp(literal("2023-09-07 05:06:14.523952")),
         f.to_timestamp_seconds(literal("2023-09-07 05:06:14.523952")),
         f.to_timestamp_millis(literal("2023-09-07 05:06:14.523952")),
         f.to_timestamp_micros(literal("2023-09-07 05:06:14.523952")),
-        # f.now(),
     )
     result = df.collect()
     assert len(result) == 1
     result = result[0]
-    assert result.column(0) == pa.array([12, 6, 7], type=pa.int32())
-    assert result.column(1) == pa.array([2022, 2027, 2020], type=pa.int32())
-    assert result.column(2) == pa.array([datetime(2022, 12, 1), datetime(2027, 6, 1), datetime(2020, 7, 1)], type=pa.timestamp("ns"))
-    assert result.column(3) == pa.array([datetime(2022, 12, 31), datetime(2027, 6, 26), datetime(2020, 7, 2)], type=pa.timestamp("ns"))
-    assert result.column(4) == pa.array([datetime(2023, 1, 10, 20, 52, 54)] * 3, type=pa.timestamp("s"))
-    assert result.column(5) == pa.array([datetime(2023, 9, 7, 5, 6, 14, 523952)] * 3, type=pa.timestamp("ns"))
-    assert result.column(6) == pa.array([datetime(2023, 9, 7, 5, 6, 14)] * 3, type=pa.timestamp("s"))
-    assert result.column(7) == pa.array([datetime(2023, 9, 7, 5, 6, 14, 523000)] * 3, type=pa.timestamp("ms"))
-    assert result.column(8) == pa.array([datetime(2023, 9, 7, 5, 6, 14, 523952)] * 3, type=pa.timestamp("us"))
+    assert result.column(0) == pa.array([12, 6, 7], type=pa.float64())
+    assert result.column(1) == pa.array([2022, 2027, 2020], type=pa.float64())
+    assert result.column(2) == pa.array(
+        [datetime(2022, 12, 1), datetime(2027, 6, 1), datetime(2020, 7, 1)],
+        type=pa.timestamp("ns"),
+    )
+    assert result.column(3) == pa.array(
+        [datetime(2022, 12, 31), datetime(2027, 6, 26), datetime(2020, 7, 2)],
+        type=pa.timestamp("ns"),
+    )
+    assert result.column(4) == pa.array(
+        [datetime(2023, 1, 10, 20, 52, 54)] * 3, type=pa.timestamp("s")
+    )
+    assert result.column(5) == pa.array(
+        [datetime(2023, 9, 7, 5, 6, 14, 523952)] * 3, type=pa.timestamp("ns")
+    )
+    assert result.column(6) == pa.array(
+        [datetime(2023, 9, 7, 5, 6, 14)] * 3, type=pa.timestamp("s")
+    )
+    assert result.column(7) == pa.array(
+        [datetime(2023, 9, 7, 5, 6, 14, 523000)] * 3, type=pa.timestamp("ms")
+    )
+    assert result.column(8) == pa.array(
+        [datetime(2023, 9, 7, 5, 6, 14, 523952)] * 3, type=pa.timestamp("us")
+    )


### PR DESCRIPTION
# Which issue does this PR close?

Closes #128

 # Rationale for this change
Improve test coverage for buit-in functions

# What changes are included in this PR?
- Expand tests for math functions
- Expand tests for string functions
- Expand tests for hash functions
- Add tests for temporal functions

# Are there any user-facing changes?
No