### PR TITLE
feature: Improve string representation of datafusion classes

### DIFF
--- a/datafusion/tests/test_udaf.py
+++ b/datafusion/tests/test_udaf.py
@@ -73,7 +73,7 @@ def df():
     return ctx.create_dataframe([[batch]])
 
 
-# @pytest.mark.skip(reason="df.collect() will hang, need more investigations")
+@pytest.mark.skip(reason="df.collect() will hang, need more investigations")
 def test_errors(df):
     with pytest.raises(TypeError):
         udaf(

--- a/datafusion/tests/test_udaf.py
+++ b/datafusion/tests/test_udaf.py
@@ -73,7 +73,7 @@ def df():
     return ctx.create_dataframe([[batch]])
 
 
-@pytest.mark.skip(reason="df.collect() will hang, need more investigations")
+# @pytest.mark.skip(reason="df.collect() will hang, need more investigations")
 def test_errors(df):
     with pytest.raises(TypeError):
         udaf(

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -83,7 +83,10 @@ impl PyCatalog {
     }
 
     fn __repr__(&self) -> PyResult<String> {
-        Ok(format!("Catalog(schema_names=[{}])", self.names().join(";")))
+        Ok(format!(
+            "Catalog(schema_names=[{}])",
+            self.names().join(";")
+        ))
     }
 }
 
@@ -102,7 +105,10 @@ impl PyDatabase {
     }
 
     fn __repr__(&self) -> PyResult<String> {
-        Ok(format!("Database(table_names=[{}])", Vec::from_iter(self.names()).join(";")))
+        Ok(format!(
+            "Database(table_names=[{}])",
+            Vec::from_iter(self.names()).join(";")
+        ))
     }
 
     // register_table
@@ -130,7 +136,6 @@ impl PyTable {
     fn __repr__(&self) -> PyResult<String> {
         let kind = self.kind();
         Ok(format!("Table(kind={})", kind))
-
     }
 
     // fn scan

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -81,6 +81,10 @@ impl PyCatalog {
             ))),
         }
     }
+
+    fn __repr__(&self) -> PyResult<String> {
+        Ok(format!("Catalog(names=[{}])", self.names().join(";")))
+    }
 }
 
 #[pymethods]
@@ -95,6 +99,10 @@ impl PyDatabase {
         } else {
             Err(DataFusionError::Common(format!("Table not found: {name}")).into())
         }
+    }
+
+    fn __repr__(&self) -> PyResult<String> {
+        Ok(format!("Database(names=[{}])", Vec::from_iter(self.names()).join(";")))
     }
 
     // register_table
@@ -117,6 +125,12 @@ impl PyTable {
             TableType::View => "view",
             TableType::Temporary => "temporary",
         }
+    }
+
+    fn __repr__(&self) -> PyResult<String> {
+        let kind = self.kind();
+        Ok(format!("Table(kind={})", kind))
+
     }
 
     // fn scan

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -83,7 +83,7 @@ impl PyCatalog {
     }
 
     fn __repr__(&self) -> PyResult<String> {
-        Ok(format!("Catalog(names=[{}])", self.names().join(";")))
+        Ok(format!("Catalog(schema_names=[{}])", self.names().join(";")))
     }
 }
 
@@ -102,7 +102,7 @@ impl PyDatabase {
     }
 
     fn __repr__(&self) -> PyResult<String> {
-        Ok(format!("Database(names=[{}])", Vec::from_iter(self.names()).join(";")))
+        Ok(format!("Database(table_names=[{}])", Vec::from_iter(self.names()).join(";")))
     }
 
     // register_table

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -135,7 +135,7 @@ impl PyTable {
 
     fn __repr__(&self) -> PyResult<String> {
         let kind = self.kind();
-        Ok(format!("Table(kind={})", kind))
+        Ok(format!("Table(kind={kind})"))
     }
 
     // fn scan

--- a/src/config.rs
+++ b/src/config.rs
@@ -76,7 +76,7 @@ impl PyConfig {
     fn __repr__(&mut self, py: Python) -> PyResult<String> {
         let dict = self.get_all(py);
         match dict {
-            Ok(result) => Ok(format!("{}", result)),
+            Ok(result) => Ok(format!("Config({})", result)),
             Err(err) => Ok(format!("Error: {:?}", err.to_string())),
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -76,7 +76,7 @@ impl PyConfig {
     fn __repr__(&mut self, py: Python) -> PyResult<String> {
         let dict = self.get_all(py);
         match dict {
-            Ok(result) => Ok(format!("Config({})", result)),
+            Ok(result) => Ok(format!("Config({result})")),
             Err(err) => Ok(format!("Error: {:?}", err.to_string())),
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -72,6 +72,14 @@ impl PyConfig {
         }
         Ok(dict.into())
     }
+
+    fn __repr__(&mut self, py: Python) -> PyResult<String> {
+        let dict = self.get_all(py);
+        match dict {
+            Ok(result) => Ok(format!("{}", result)),
+            Err(err) => Ok(format!("Error: {:?}", err.to_string())),
+        }
+    }
 }
 
 /// Convert a python object to a ScalarValue

--- a/src/context.rs
+++ b/src/context.rs
@@ -464,7 +464,7 @@ impl PySessionContext {
     fn __repr__(&self) -> PyResult<String> {
         let id = self.session_id();
         match id {
-            Ok(value) => Ok(format!("SessionContext(session_id={})", value)),
+            Ok(value) => Ok(format!("SessionContext(session_id={value})")),
             Err(err) => Ok(format!("Error: {:?}", err.to_string())),
         }
     }

--- a/src/context.rs
+++ b/src/context.rs
@@ -460,6 +460,14 @@ impl PySessionContext {
         };
         Ok(PyDataFrame::new(df))
     }
+
+    fn __repr__(&self) -> PyResult<String> {
+        let id = self.session_id();
+        match id {
+            Ok(value) => Ok(format!("SessionContext(session_id={})", value)),
+            Err(err) => Ok(format!("Error: {:?}", err.to_string())),
+        }
+    }
 }
 
 impl PySessionContext {

--- a/src/dataframe.rs
+++ b/src/dataframe.rs
@@ -66,22 +66,12 @@ impl PyDataFrame {
         })
     }
 
-    fn __str__(&self, py: Python) -> PyResult<String> {
-        let df = self.df.as_ref().clone().limit(0, Some(10))?;
-        let batches = wait_for_future(py, df.collect())?;
-        let batches_as_string = pretty::pretty_format_batches(&batches);
-        match batches_as_string {
-            Ok(batch) => Ok(format!("{}", batch)),
-            Err(err) => Ok(format!("Error: {:?}", err.to_string())),
-        }
-    }
-
     fn __repr__(&self, py: Python) -> PyResult<String> {
         let df = self.df.as_ref().clone().limit(0, Some(10))?;
         let batches = wait_for_future(py, df.collect())?;
         let batches_as_string = pretty::pretty_format_batches(&batches);
         match batches_as_string {
-            Ok(batch) => Ok(format!("{}", batch)),
+            Ok(batch) => Ok(format!("DataFrame()\n{}", batch)),
             Err(err) => Ok(format!("Error: {:?}", err.to_string())),
         }
     }

--- a/src/dataframe.rs
+++ b/src/dataframe.rs
@@ -66,6 +66,26 @@ impl PyDataFrame {
         })
     }
 
+    fn __str__(&self, py: Python) -> PyResult<String> {
+        let df = self.df.as_ref().clone().limit(0, Some(10))?;
+        let batches = wait_for_future(py, df.collect())?;
+        let batches_as_string = pretty::pretty_format_batches(&batches);
+        match batches_as_string {
+            Ok(batch) => Ok(format!("{}", batch)),
+            Err(err) => Ok(format!("Error: {:?}", err.to_string())),
+        }
+    }
+
+    fn __repr__(&self, py: Python) -> PyResult<String> {
+        let df = self.df.as_ref().clone().limit(0, Some(10))?;
+        let batches = wait_for_future(py, df.collect())?;
+        let batches_as_string = pretty::pretty_format_batches(&batches);
+        match batches_as_string {
+            Ok(batch) => Ok(format!("{}", batch)),
+            Err(err) => Ok(format!("Error: {:?}", err.to_string())),
+        }
+    }
+
     /// Returns the schema from the logical plan
     fn schema(&self) -> PyArrowType<Schema> {
         PyArrowType(self.df.schema().into())

--- a/src/dataframe.rs
+++ b/src/dataframe.rs
@@ -71,7 +71,7 @@ impl PyDataFrame {
         let batches = wait_for_future(py, df.collect())?;
         let batches_as_string = pretty::pretty_format_batches(&batches);
         match batches_as_string {
-            Ok(batch) => Ok(format!("DataFrame()\n{}", batch)),
+            Ok(batch) => Ok(format!("DataFrame()\n{batch}")),
             Err(err) => Ok(format!("Error: {:?}", err.to_string())),
         }
     }

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -61,6 +61,10 @@ impl PyExpr {
         Ok(format!("{}", self.expr))
     }
 
+    fn __repr__(&self) -> PyResult<String> {
+        Ok(format!("{}", self.expr))
+    }
+
     fn __add__(&self, rhs: PyExpr) -> PyResult<PyExpr> {
         Ok((self.expr.clone() + rhs.expr).into())
     }

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -57,12 +57,8 @@ impl PyExpr {
         expr.into()
     }
 
-    fn __str__(&self) -> PyResult<String> {
-        Ok(format!("{}", self.expr))
-    }
-
     fn __repr__(&self) -> PyResult<String> {
-        Ok(format!("{}", self.expr))
+        Ok(format!("Expr({})", self.expr))
     }
 
     fn __add__(&self, rhs: PyExpr) -> PyResult<PyExpr> {

--- a/src/udaf.rs
+++ b/src/udaf.rs
@@ -141,4 +141,8 @@ impl PyAggregateUDF {
         let args = args.iter().map(|e| e.expr.clone()).collect();
         Ok(self.function.call(args).into())
     }
+
+    fn __repr__(&self) -> PyResult<String> {
+        Ok(format!("AggregateUDF({})", self.function.name))
+    }
 }

--- a/src/udf.rs
+++ b/src/udf.rs
@@ -92,4 +92,8 @@ impl PyScalarUDF {
         let args = args.iter().map(|e| e.expr.clone()).collect();
         Ok(self.function.call(args).into())
     }
+
+    fn __repr__(&self) -> PyResult<String> {
+        Ok(format!("ScalarUDF({})", self.function.name))
+    }
 }


### PR DESCRIPTION
# Which issue does this PR close?
Closes #158.

 # Rationale for this change
Improve developer experience

# What changes are included in this PR?
Implement `__repr__` methods of the following classes:
- DataFrame
- Expression
- Context
- Catalog
- Database
- Table
- Config
- UDAF & UDF

# Are there any user-facing changes?
Display additional information when debugging or using REPL tools
