### PR TITLE
feature: Implement count method

### DIFF
--- a/datafusion/tests/test_dataframe.py
+++ b/datafusion/tests/test_dataframe.py
@@ -453,3 +453,8 @@ def test_union_distinct(ctx):
 
 def test_cache(df):
     assert df.cache().collect() == df.collect()
+
+
+def test_count(df):
+    # Get number of rows
+    assert df.count() == 3

--- a/src/dataframe.rs
+++ b/src/dataframe.rs
@@ -312,4 +312,10 @@ impl PyDataFrame {
         wait_for_future(py, self.df.as_ref().clone().write_json(path))?;
         Ok(())
     }
+
+    // Executes this DataFrame to get the total number of rows.
+    fn count(&self, py: Python) -> PyResult<usize> {
+        let count = wait_for_future(py, self.df.as_ref().clone().count());
+        Ok(count.unwrap())
+    }
 }

--- a/src/dataframe.rs
+++ b/src/dataframe.rs
@@ -315,7 +315,6 @@ impl PyDataFrame {
 
     // Executes this DataFrame to get the total number of rows.
     fn count(&self, py: Python) -> PyResult<usize> {
-        let count = wait_for_future(py, self.df.as_ref().clone().count());
-        Ok(count.unwrap())
+        Ok(wait_for_future(py, self.df.as_ref().clone().count())?)
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?
Closes #151

 # Rationale for this change
Implement count method in Python bindings after it got introduced in Rust.

# What changes are included in this PR?


# Are there any user-facing changes?
Make `.count()` available