### PR TITLE
Make from_substrait_plan return DataFrame instead of LogicalPlan

### DIFF
--- a/datafusion/tests/test_substrait.py
+++ b/datafusion/tests/test_substrait.py
@@ -49,6 +49,7 @@ def test_substrait_serialization(ctx):
         ctx, substrait_plan
     )
 
+    # demonstrate how to create a DataFrame from a deserialized logical plan
     df = ctx.create_dataframe_from_logical_plan(logical_plan)
 
-    substrait_plan = ss.substrait.producer.to_substrait_plan(logical_plan)
+    substrait_plan = ss.substrait.producer.to_substrait_plan(df.logical_plan())

--- a/datafusion/tests/test_substrait.py
+++ b/datafusion/tests/test_substrait.py
@@ -45,7 +45,10 @@ def test_substrait_serialization(ctx):
         "SELECT * FROM t", ctx
     )
     substrait_plan = ss.substrait.serde.deserialize_bytes(substrait_bytes)
-    df_logical_plan = ss.substrait.consumer.from_substrait_plan(
+    logical_plan = ss.substrait.consumer.from_substrait_plan(
         ctx, substrait_plan
     )
-    substrait_plan = ss.substrait.producer.to_substrait_plan(df_logical_plan)
+
+    df = ctx.create_dataframe_from_logical_plan(logical_plan)
+
+    substrait_plan = ss.substrait.producer.to_substrait_plan(logical_plan)

--- a/src/context.rs
+++ b/src/context.rs
@@ -29,6 +29,7 @@ use crate::catalog::{PyCatalog, PyTable};
 use crate::dataframe::PyDataFrame;
 use crate::dataset::Dataset;
 use crate::errors::DataFusionError;
+use crate::logical::PyLogicalPlan;
 use crate::store::StorageContexts;
 use crate::udaf::PyAggregateUDF;
 use crate::udf::PyScalarUDF;
@@ -43,7 +44,6 @@ use datafusion::prelude::{
     AvroReadOptions, CsvReadOptions, DataFrame, NdJsonReadOptions, ParquetReadOptions,
 };
 use datafusion_common::ScalarValue;
-use crate::logical::PyLogicalPlan;
 
 /// `PySessionContext` is able to plan and execute DataFusion plans.
 /// It has a powerful optimizer, a physical planner for local execution, and a
@@ -177,10 +177,7 @@ impl PySessionContext {
     }
 
     /// Create a DataFrame from an existing logical plan
-    fn create_dataframe_from_logical_plan(
-        &mut self,
-        plan: PyLogicalPlan,
-    ) -> PyDataFrame {
+    fn create_dataframe_from_logical_plan(&mut self, plan: PyLogicalPlan) -> PyDataFrame {
         PyDataFrame::new(DataFrame::new(self.ctx.state(), plan.plan.as_ref().clone()))
     }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -43,6 +43,7 @@ use datafusion::prelude::{
     AvroReadOptions, CsvReadOptions, DataFrame, NdJsonReadOptions, ParquetReadOptions,
 };
 use datafusion_common::ScalarValue;
+use crate::logical::PyLogicalPlan;
 
 /// `PySessionContext` is able to plan and execute DataFusion plans.
 /// It has a powerful optimizer, a physical planner for local execution, and a
@@ -173,6 +174,14 @@ impl PySessionContext {
 
         let df = PyDataFrame::new(table);
         Ok(df)
+    }
+
+    /// Create a DataFrame from an existing logical plan
+    fn create_dataframe_from_logical_plan(
+        &mut self,
+        plan: PyLogicalPlan,
+    ) -> PyDataFrame {
+        PyDataFrame::new(DataFrame::new(self.ctx.state(), plan.plan.as_ref().clone()))
     }
 
     fn register_table(&mut self, name: &str, table: &PyTable) -> PyResult<()> {


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

I want to be able to execute a substrait plan and there is no way to do that after deserializing a logical plan from substrait.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Change `from_substrait_plan` to return `DataFrame` instead of `LogicalPlan`

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->