### PR TITLE
Allow memory pool and disk spilling to be configured

### DIFF
--- a/datafusion/tests/test_context.py
+++ b/datafusion/tests/test_context.py
@@ -40,6 +40,8 @@ def test_create_context_with_all_valid_args():
         repartition_windows=False,
         parquet_pruning=False,
         config_options=None,
+        memory_pool_size=1073741824,
+        spill_path="."
     )
 
     # verify that at least some of the arguments worked

--- a/examples/dataframe-parquet.py
+++ b/examples/dataframe-parquet.py
@@ -18,7 +18,7 @@
 from datafusion import SessionContext
 from datafusion import functions as f
 
-ctx = SessionContext()
+ctx = SessionContext(memory_pool_size=1073741824, spill_path="/tmp")
 df = ctx.read_parquet(
     "/mnt/bigdata/nyctaxi/yellow/2021/yellow_tripdata_2021-01.parquet"
 ).aggregate([f.col("passenger_count")], [f.count_star()])

--- a/examples/sql-parquet.py
+++ b/examples/sql-parquet.py
@@ -17,7 +17,7 @@
 
 from datafusion import SessionContext
 
-ctx = SessionContext()
+ctx = SessionContext(memory_pool_size=1073741824, spill_path="/tmp")
 ctx.register_parquet(
     "taxi", "/mnt/bigdata/nyctaxi/yellow/2021/yellow_tripdata_2021-01.parquet"
 )

--- a/examples/sql-to-pandas.py
+++ b/examples/sql-to-pandas.py
@@ -19,7 +19,7 @@ from datafusion import SessionContext
 
 
 # Create a DataFusion context
-ctx = SessionContext()
+ctx = SessionContext(memory_pool_size=1073741824, spill_path="/tmp")
 
 # Register table with context
 ctx.register_parquet("taxi", "yellow_tripdata_2021-01.parquet")


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/arrow-datafusion-python/issues/157

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Allow memory and disk spilling to be configured from Python

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Add new parameters to context constructor

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

No

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->