### PR TITLE
Add ability to execute ExecutionPlan and get a stream of RecordBatch

### DIFF
--- a/datafusion/tests/test_dataframe.py
+++ b/datafusion/tests/test_dataframe.py
@@ -388,6 +388,10 @@ def test_execution_plan(aggregate_df):
     assert "RepartitionExec:" in indent
     assert "CsvExec:" in indent
 
+    stream = plan.execute(0)
+    batch = stream.next()
+    print(batch)
+
 
 def test_repartition(df):
     df.repartition(2)

--- a/datafusion/tests/test_dataframe.py
+++ b/datafusion/tests/test_dataframe.py
@@ -390,8 +390,12 @@ def test_execution_plan(aggregate_df):
 
     ctx = SessionContext()
     stream = ctx.execute(plan, 0)
+    # get the one and only batch
     batch = stream.next()
-    print(batch)
+    assert batch is not None
+    # there should be no more batches
+    batch = stream.next()
+    assert batch is None
 
 
 def test_repartition(df):

--- a/datafusion/tests/test_dataframe.py
+++ b/datafusion/tests/test_dataframe.py
@@ -388,7 +388,8 @@ def test_execution_plan(aggregate_df):
     assert "RepartitionExec:" in indent
     assert "CsvExec:" in indent
 
-    stream = plan.execute(0)
+    ctx = SessionContext()
+    stream = ctx.execute(plan, 0)
     batch = stream.next()
     print(batch)
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -601,8 +601,6 @@ impl PySessionContext {
             Arc::new(RuntimeEnv::default()),
         ));
         // create a Tokio runtime to run the async code
-        //TODO can we use an existing runtime from the SessionContext ? If not, we at least
-        // need to configure the runtime here
         let rt = Runtime::new().unwrap();
         let plan = plan.plan.clone();
         let fut: JoinHandle<datafusion_common::Result<SendableRecordBatchStream>> =

--- a/src/context.rs
+++ b/src/context.rs
@@ -28,7 +28,9 @@ use pyo3::prelude::*;
 use crate::catalog::{PyCatalog, PyTable};
 use crate::dataframe::PyDataFrame;
 use crate::dataset::Dataset;
-use crate::errors::DataFusionError;
+use crate::errors::{py_datafusion_err, DataFusionError};
+use crate::physical_plan::PyExecutionPlan;
+use crate::record_batch::PyRecordBatchStream;
 use crate::sql::logical::PyLogicalPlan;
 use crate::store::StorageContexts;
 use crate::udaf::PyAggregateUDF;
@@ -39,14 +41,17 @@ use datafusion::arrow::pyarrow::PyArrowType;
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::datasource::datasource::TableProvider;
 use datafusion::datasource::MemTable;
-use datafusion::execution::context::{SessionConfig, SessionContext};
+use datafusion::execution::context::{SessionConfig, SessionContext, TaskContext};
 use datafusion::execution::disk_manager::DiskManagerConfig;
 use datafusion::execution::memory_pool::{FairSpillPool, GreedyMemoryPool, UnboundedMemoryPool};
 use datafusion::execution::runtime_env::{RuntimeConfig, RuntimeEnv};
+use datafusion::physical_plan::SendableRecordBatchStream;
 use datafusion::prelude::{
     AvroReadOptions, CsvReadOptions, DataFrame, NdJsonReadOptions, ParquetReadOptions,
 };
 use datafusion_common::ScalarValue;
+use tokio::runtime::Runtime;
+use tokio::task::JoinHandle;
 
 #[pyclass(name = "SessionConfig", module = "datafusion", subclass, unsendable)]
 #[derive(Clone, Default)]
@@ -578,6 +583,32 @@ impl PySessionContext {
             Ok(value) => Ok(format!("SessionContext(session_id={value})")),
             Err(err) => Ok(format!("Error: {:?}", err.to_string())),
         }
+    }
+
+    /// Execute a partition of an execution plan and return a stream of record batches
+    pub fn execute(
+        &self,
+        plan: PyExecutionPlan,
+        part: usize,
+        py: Python,
+    ) -> PyResult<PyRecordBatchStream> {
+        let ctx = Arc::new(TaskContext::new(
+            "task_id".to_string(),
+            "session_id".to_string(),
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::new(),
+            Arc::new(RuntimeEnv::default()),
+        ));
+        // create a Tokio runtime to run the async code
+        //TODO can we use an existing runtime from the SessionContext ? If not, we at least
+        // need to configure the runtime here
+        let rt = Runtime::new().unwrap();
+        let plan = plan.plan.clone();
+        let fut: JoinHandle<datafusion_common::Result<SendableRecordBatchStream>> =
+            rt.spawn(async move { plan.execute(part, ctx) });
+        let stream = wait_for_future(py, fut).map_err(|e| py_datafusion_err(e))?;
+        Ok(PyRecordBatchStream::new(stream?))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,7 @@ mod expr;
 mod functions;
 pub mod physical_plan;
 mod pyarrow_filter_expression;
+mod record_batch;
 pub mod sql;
 pub mod store;
 pub mod substrait;

--- a/src/physical_plan.rs
+++ b/src/physical_plan.rs
@@ -15,20 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use datafusion::execution::context::TaskContext;
-use datafusion::execution::runtime_env::RuntimeEnv;
-use datafusion::physical_plan::{displayable, ExecutionPlan, SendableRecordBatchStream};
-use datafusion_common::Result;
-use futures::StreamExt;
-use std::collections::HashMap;
+use datafusion::physical_plan::{displayable, ExecutionPlan};
 use std::sync::Arc;
 
-use crate::errors::py_datafusion_err;
-use crate::record_batch::PyRecordBatch;
-use crate::utils::wait_for_future;
 use pyo3::prelude::*;
-use tokio::runtime::Runtime;
-use tokio::task::JoinHandle;
 
 #[pyclass(name = "ExecutionPlan", module = "datafusion", subclass)]
 #[derive(Debug, Clone)]
@@ -63,24 +53,6 @@ impl PyExecutionPlan {
         let d = displayable(self.plan.as_ref());
         format!("{}", d.indent())
     }
-
-    pub fn execute(&self, part: usize, py: Python) -> PyResult<PyRecordBatchStream> {
-        let ctx = Arc::new(TaskContext::new(
-            "task_id".to_string(),
-            "session_id".to_string(),
-            HashMap::new(),
-            HashMap::new(),
-            HashMap::new(),
-            Arc::new(RuntimeEnv::default()),
-        ));
-        // create a Tokio runtime to run the async code
-        let rt = Runtime::new().unwrap();
-        let plan = self.plan.clone();
-        let fut: JoinHandle<Result<SendableRecordBatchStream>> =
-            rt.spawn(async move { plan.execute(part, ctx) });
-        let stream = wait_for_future(py, fut).map_err(|e| py_datafusion_err(e))?;
-        Ok(PyRecordBatchStream::new(stream?))
-    }
 }
 
 impl From<PyExecutionPlan> for Arc<dyn ExecutionPlan> {
@@ -92,25 +64,5 @@ impl From<PyExecutionPlan> for Arc<dyn ExecutionPlan> {
 impl From<Arc<dyn ExecutionPlan>> for PyExecutionPlan {
     fn from(plan: Arc<dyn ExecutionPlan>) -> PyExecutionPlan {
         PyExecutionPlan { plan: plan.clone() }
-    }
-}
-
-#[pyclass(name = "RecordBatchStream", module = "datafusion", subclass)]
-pub struct PyRecordBatchStream {
-    stream: SendableRecordBatchStream,
-}
-
-impl PyRecordBatchStream {
-    fn new(stream: SendableRecordBatchStream) -> Self {
-        Self { stream }
-    }
-}
-
-#[pymethods]
-impl PyRecordBatchStream {
-    fn next(&mut self, py: Python) -> PyResult<PyRecordBatch> {
-        let result = self.stream.next();
-        let batch = wait_for_future(py, result).unwrap()?; //.map_err(DataFusionError::from)?;
-        Ok(batch.into())
     }
 }

--- a/src/physical_plan.rs
+++ b/src/physical_plan.rs
@@ -15,10 +15,20 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use datafusion::physical_plan::{displayable, ExecutionPlan};
+use datafusion::execution::context::TaskContext;
+use datafusion::execution::runtime_env::RuntimeEnv;
+use datafusion::physical_plan::{displayable, ExecutionPlan, SendableRecordBatchStream};
+use datafusion_common::Result;
+use futures::StreamExt;
+use std::collections::HashMap;
 use std::sync::Arc;
 
+use crate::errors::py_datafusion_err;
+use crate::record_batch::PyRecordBatch;
+use crate::utils::wait_for_future;
 use pyo3::prelude::*;
+use tokio::runtime::Runtime;
+use tokio::task::JoinHandle;
 
 #[pyclass(name = "ExecutionPlan", module = "datafusion", subclass)]
 #[derive(Debug, Clone)]
@@ -53,6 +63,24 @@ impl PyExecutionPlan {
         let d = displayable(self.plan.as_ref());
         format!("{}", d.indent())
     }
+
+    pub fn execute(&self, part: usize, py: Python) -> PyResult<PyRecordBatchStream> {
+        let ctx = Arc::new(TaskContext::new(
+            "task_id".to_string(),
+            "session_id".to_string(),
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::new(),
+            Arc::new(RuntimeEnv::default()),
+        ));
+        // create a Tokio runtime to run the async code
+        let rt = Runtime::new().unwrap();
+        let plan = self.plan.clone();
+        let fut: JoinHandle<Result<SendableRecordBatchStream>> =
+            rt.spawn(async move { plan.execute(part, ctx) });
+        let stream = wait_for_future(py, fut).map_err(|e| py_datafusion_err(e))?;
+        Ok(PyRecordBatchStream::new(stream?))
+    }
 }
 
 impl From<PyExecutionPlan> for Arc<dyn ExecutionPlan> {
@@ -64,5 +92,25 @@ impl From<PyExecutionPlan> for Arc<dyn ExecutionPlan> {
 impl From<Arc<dyn ExecutionPlan>> for PyExecutionPlan {
     fn from(plan: Arc<dyn ExecutionPlan>) -> PyExecutionPlan {
         PyExecutionPlan { plan: plan.clone() }
+    }
+}
+
+#[pyclass(name = "RecordBatchStream", module = "datafusion", subclass)]
+pub struct PyRecordBatchStream {
+    stream: SendableRecordBatchStream,
+}
+
+impl PyRecordBatchStream {
+    fn new(stream: SendableRecordBatchStream) -> Self {
+        Self { stream }
+    }
+}
+
+#[pymethods]
+impl PyRecordBatchStream {
+    fn next(&mut self, py: Python) -> PyResult<PyRecordBatch> {
+        let result = self.stream.next();
+        let batch = wait_for_future(py, result).unwrap()?; //.map_err(DataFusionError::from)?;
+        Ok(batch.into())
     }
 }

--- a/src/record_batch.rs
+++ b/src/record_batch.rs
@@ -1,0 +1,38 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use datafusion::arrow::pyarrow::PyArrowConvert;
+use datafusion::arrow::record_batch::RecordBatch;
+use pyo3::{pyclass, pymethods, PyObject, PyResult, Python};
+
+#[pyclass(name = "RecordBatch", module = "datafusion", subclass)]
+pub struct PyRecordBatch {
+    batch: RecordBatch,
+}
+
+#[pymethods]
+impl PyRecordBatch {
+    fn to_pyarrow(&self, py: Python) -> PyResult<PyObject> {
+        self.batch.to_pyarrow(py)
+    }
+}
+
+impl From<RecordBatch> for PyRecordBatch {
+    fn from(batch: RecordBatch) -> Self {
+        Self { batch }
+    }
+}


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Allow Python code to execute a Rust ExecutionPlan and fetch the stream of batches.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->