### PR TITLE
feature: Additional export methods

### DIFF
--- a/datafusion/tests/test_dataframe.py
+++ b/datafusion/tests/test_dataframe.py
@@ -131,9 +131,7 @@ def test_with_column(df):
 
 
 def test_with_column_renamed(df):
-    df = df.with_column("c", column("a") + column("b")).with_column_renamed(
-        "c", "sum"
-    )
+    df = df.with_column("c", column("a") + column("b")).with_column_renamed("c", "sum")
 
     result = df.collect()[0]
 
@@ -197,9 +195,7 @@ def test_distinct():
         [pa.array([1, 2, 3]), pa.array([4, 5, 6])],
         names=["a", "b"],
     )
-    df_b = ctx.create_dataframe([[batch]]).sort(
-        column("a").sort(ascending=True)
-    )
+    df_b = ctx.create_dataframe([[batch]]).sort(column("a").sort(ascending=True))
 
     assert df_a.collect() == df_b.collect()
 
@@ -230,9 +226,7 @@ def test_window_functions(df):
             "cume_dist",
         ),
         f.alias(
-            f.window(
-                "ntile", [literal(2)], order_by=[f.order_by(column("c"))]
-            ),
+            f.window("ntile", [literal(2)], order_by=[f.order_by(column("c"))]),
             "ntile",
         ),
         f.alias(
@@ -240,9 +234,7 @@ def test_window_functions(df):
             "previous",
         ),
         f.alias(
-            f.window(
-                "lead", [column("b")], order_by=[f.order_by(column("b"))]
-            ),
+            f.window("lead", [column("b")], order_by=[f.order_by(column("b"))]),
             "next",
         ),
         f.alias(
@@ -254,9 +246,7 @@ def test_window_functions(df):
             "first_value",
         ),
         f.alias(
-            f.window(
-                "last_value", [column("b")], order_by=[f.order_by(column("b"))]
-            ),
+            f.window("last_value", [column("b")], order_by=[f.order_by(column("b"))]),
             "last_value",
         ),
         f.alias(
@@ -366,9 +356,7 @@ def test_optimized_logical_plan(aggregate_df):
 def test_execution_plan(aggregate_df):
     plan = aggregate_df.execution_plan()
 
-    expected = (
-        "ProjectionExec: expr=[c1@0 as c1, SUM(test.c2)@1 as SUM(test.c2)]\n"
-    )
+    expected = "ProjectionExec: expr=[c1@0 as c1, SUM(test.c2)@1 as SUM(test.c2)]\n"
 
     assert expected == plan.display()
 
@@ -425,9 +413,7 @@ def test_intersect():
         [pa.array([3]), pa.array([6])],
         names=["a", "b"],
     )
-    df_c = ctx.create_dataframe([[batch]]).sort(
-        column("a").sort(ascending=True)
-    )
+    df_c = ctx.create_dataframe([[batch]]).sort(column("a").sort(ascending=True))
 
     df_a_i_b = df_a.intersect(df_b).sort(column("a").sort(ascending=True))
 
@@ -453,9 +439,7 @@ def test_except_all():
         [pa.array([1, 2]), pa.array([4, 5])],
         names=["a", "b"],
     )
-    df_c = ctx.create_dataframe([[batch]]).sort(
-        column("a").sort(ascending=True)
-    )
+    df_c = ctx.create_dataframe([[batch]]).sort(column("a").sort(ascending=True))
 
     df_a_e_b = df_a.except_all(df_b).sort(column("a").sort(ascending=True))
 
@@ -490,9 +474,7 @@ def test_union(ctx):
         [pa.array([1, 2, 3, 3, 4, 5]), pa.array([4, 5, 6, 6, 7, 8])],
         names=["a", "b"],
     )
-    df_c = ctx.create_dataframe([[batch]]).sort(
-        column("a").sort(ascending=True)
-    )
+    df_c = ctx.create_dataframe([[batch]]).sort(column("a").sort(ascending=True))
 
     df_a_u_b = df_a.union(df_b).sort(column("a").sort(ascending=True))
 
@@ -516,9 +498,7 @@ def test_union_distinct(ctx):
         [pa.array([1, 2, 3, 4, 5]), pa.array([4, 5, 6, 7, 8])],
         names=["a", "b"],
     )
-    df_c = ctx.create_dataframe([[batch]]).sort(
-        column("a").sort(ascending=True)
-    )
+    df_c = ctx.create_dataframe([[batch]]).sort(column("a").sort(ascending=True))
 
     df_a_u_b = df_a.union(df_b, True).sort(column("a").sort(ascending=True))
 
@@ -546,11 +526,30 @@ def test_to_pandas(df):
     assert set(pandas_df.columns) == {"a", "b", "c"}
 
 
+def test_empty_to_pandas(df):
+    # Skip test if pandas is not installed
+    pd = pytest.importorskip("pandas")
+
+    # Convert empty datafusion dataframe to pandas dataframe
+    pandas_df = df.limit(0).to_pandas()
+    assert type(pandas_df) == pd.DataFrame
+    assert pandas_df.shape == (0, 3)
+    assert set(pandas_df.columns) == {"a", "b", "c"}
+
+
 def test_to_arrow_table(df):
     # Convert datafusion dataframe to pyarrow Table
     pyarrow_table = df.to_arrow_table()
     assert type(pyarrow_table) == pa.Table
     assert pyarrow_table.shape == (3, 3)
+    assert set(pyarrow_table.column_names) == {"a", "b", "c"}
+
+
+def test_empty_to_arrow_table(df):
+    # Convert empty datafusion dataframe to pyarrow Table
+    pyarrow_table = df.limit(0).to_arrow_table()
+    assert type(pyarrow_table) == pa.Table
+    assert pyarrow_table.shape == (0, 3)
     assert set(pyarrow_table.column_names) == {"a", "b", "c"}
 
 

--- a/datafusion/tests/test_dataframe.py
+++ b/datafusion/tests/test_dataframe.py
@@ -131,7 +131,9 @@ def test_with_column(df):
 
 
 def test_with_column_renamed(df):
-    df = df.with_column("c", column("a") + column("b")).with_column_renamed("c", "sum")
+    df = df.with_column("c", column("a") + column("b")).with_column_renamed(
+        "c", "sum"
+    )
 
     result = df.collect()[0]
 
@@ -195,7 +197,9 @@ def test_distinct():
         [pa.array([1, 2, 3]), pa.array([4, 5, 6])],
         names=["a", "b"],
     )
-    df_b = ctx.create_dataframe([[batch]]).sort(column("a").sort(ascending=True))
+    df_b = ctx.create_dataframe([[batch]]).sort(
+        column("a").sort(ascending=True)
+    )
 
     assert df_a.collect() == df_b.collect()
 
@@ -226,7 +230,9 @@ def test_window_functions(df):
             "cume_dist",
         ),
         f.alias(
-            f.window("ntile", [literal(2)], order_by=[f.order_by(column("c"))]),
+            f.window(
+                "ntile", [literal(2)], order_by=[f.order_by(column("c"))]
+            ),
             "ntile",
         ),
         f.alias(
@@ -234,7 +240,9 @@ def test_window_functions(df):
             "previous",
         ),
         f.alias(
-            f.window("lead", [column("b")], order_by=[f.order_by(column("b"))]),
+            f.window(
+                "lead", [column("b")], order_by=[f.order_by(column("b"))]
+            ),
             "next",
         ),
         f.alias(
@@ -246,7 +254,9 @@ def test_window_functions(df):
             "first_value",
         ),
         f.alias(
-            f.window("last_value", [column("b")], order_by=[f.order_by(column("b"))]),
+            f.window(
+                "last_value", [column("b")], order_by=[f.order_by(column("b"))]
+            ),
             "last_value",
         ),
         f.alias(
@@ -356,7 +366,9 @@ def test_optimized_logical_plan(aggregate_df):
 def test_execution_plan(aggregate_df):
     plan = aggregate_df.execution_plan()
 
-    expected = "ProjectionExec: expr=[c1@0 as c1, SUM(test.c2)@1 as SUM(test.c2)]\n"
+    expected = (
+        "ProjectionExec: expr=[c1@0 as c1, SUM(test.c2)@1 as SUM(test.c2)]\n"
+    )
 
     assert expected == plan.display()
 
@@ -413,7 +425,9 @@ def test_intersect():
         [pa.array([3]), pa.array([6])],
         names=["a", "b"],
     )
-    df_c = ctx.create_dataframe([[batch]]).sort(column("a").sort(ascending=True))
+    df_c = ctx.create_dataframe([[batch]]).sort(
+        column("a").sort(ascending=True)
+    )
 
     df_a_i_b = df_a.intersect(df_b).sort(column("a").sort(ascending=True))
 
@@ -439,7 +453,9 @@ def test_except_all():
         [pa.array([1, 2]), pa.array([4, 5])],
         names=["a", "b"],
     )
-    df_c = ctx.create_dataframe([[batch]]).sort(column("a").sort(ascending=True))
+    df_c = ctx.create_dataframe([[batch]]).sort(
+        column("a").sort(ascending=True)
+    )
 
     df_a_e_b = df_a.except_all(df_b).sort(column("a").sort(ascending=True))
 
@@ -474,7 +490,9 @@ def test_union(ctx):
         [pa.array([1, 2, 3, 3, 4, 5]), pa.array([4, 5, 6, 6, 7, 8])],
         names=["a", "b"],
     )
-    df_c = ctx.create_dataframe([[batch]]).sort(column("a").sort(ascending=True))
+    df_c = ctx.create_dataframe([[batch]]).sort(
+        column("a").sort(ascending=True)
+    )
 
     df_a_u_b = df_a.union(df_b).sort(column("a").sort(ascending=True))
 
@@ -498,7 +516,9 @@ def test_union_distinct(ctx):
         [pa.array([1, 2, 3, 4, 5]), pa.array([4, 5, 6, 7, 8])],
         names=["a", "b"],
     )
-    df_c = ctx.create_dataframe([[batch]]).sort(column("a").sort(ascending=True))
+    df_c = ctx.create_dataframe([[batch]]).sort(
+        column("a").sort(ascending=True)
+    )
 
     df_a_u_b = df_a.union(df_b, True).sort(column("a").sort(ascending=True))
 

--- a/datafusion/tests/test_dataframe.py
+++ b/datafusion/tests/test_dataframe.py
@@ -544,3 +544,29 @@ def test_to_pandas(df):
     assert type(pandas_df) == pd.DataFrame
     assert pandas_df.shape == (3, 3)
     assert set(pandas_df.columns) == {"a", "b", "c"}
+
+
+def test_to_arrow_table(df):
+    # Convert datafusion dataframe to pyarrow Table
+    pyarrow_table = df.to_arrow_table()
+    assert type(pyarrow_table) == pa.Table
+    assert pyarrow_table.shape == (3, 3)
+    assert set(pyarrow_table.column_names) == {"a", "b", "c"}
+
+
+def test_to_pylist(df):
+    # Convert datafusion dataframe to Python list
+    pylist = df.to_pylist()
+    assert type(pylist) == list
+    assert pylist == [
+        {"a": 1, "b": 4, "c": 8},
+        {"a": 2, "b": 5, "c": 5},
+        {"a": 3, "b": 6, "c": 8},
+    ]
+
+
+def test_to_pydict(df):
+    # Convert datafusion dataframe to Python dictionary
+    pydict = df.to_pydict()
+    assert type(pydict) == dict
+    assert pydict == {"a": [1, 2, 3], "b": [4, 5, 6], "c": [8, 5, 8]}

--- a/datafusion/tests/test_dataframe.py
+++ b/datafusion/tests/test_dataframe.py
@@ -557,6 +557,28 @@ def test_empty_to_pandas(df):
     assert set(pandas_df.columns) == {"a", "b", "c"}
 
 
+def test_to_polars(df):
+    # Skip test if polars is not installed
+    pl = pytest.importorskip("polars")
+
+    # Convert datafusion dataframe to polars dataframe
+    polars_df = df.to_polars()
+    assert type(polars_df) == pl.DataFrame
+    assert polars_df.shape == (3, 3)
+    assert set(polars_df.columns) == {"a", "b", "c"}
+
+
+def test_empty_to_polars(df):
+    # Skip test if polars is not installed
+    pl = pytest.importorskip("polars")
+
+    # Convert empty datafusion dataframe to polars dataframe
+    polars_df = df.limit(0).to_polars()
+    assert type(polars_df) == pl.DataFrame
+    assert polars_df.shape == (0, 3)
+    assert set(polars_df.columns) == {"a", "b", "c"}
+
+
 def test_to_arrow_table(df):
     # Convert datafusion dataframe to pyarrow Table
     pyarrow_table = df.to_arrow_table()

--- a/examples/export.py
+++ b/examples/export.py
@@ -16,7 +16,6 @@
 # under the License.
 
 import datafusion
-from datafusion import col
 import pyarrow
 import polars as pl
 

--- a/examples/export.py
+++ b/examples/export.py
@@ -47,7 +47,7 @@ arrow_table = df.to_arrow_table()
 assert arrow_table.shape == (3, 2)
 
 # export to Polars dataframe
-polars_df = pl.DataFrame(df.to_arrow_table())
+polars_df = df.to_polars()
 assert polars_df.shape == (3, 2)
 
 # export to Python list of rows

--- a/examples/export.py
+++ b/examples/export.py
@@ -17,7 +17,6 @@
 
 import datafusion
 import pyarrow
-import polars as pl
 
 
 # create a context

--- a/examples/export.py
+++ b/examples/export.py
@@ -1,0 +1,60 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import datafusion
+from datafusion import col
+import pyarrow
+import polars as pl
+
+
+# create a context
+ctx = datafusion.SessionContext()
+
+# create a RecordBatch and a new datafusion DataFrame from it
+batch = pyarrow.RecordBatch.from_arrays(
+    [pyarrow.array([1, 2, 3]), pyarrow.array([4, 5, 6])],
+    names=["a", "b"],
+)
+df = ctx.create_dataframe([[batch]])
+# Dataframe:
+# +---+---+
+# | a | b |
+# +---+---+
+# | 1 | 4 |
+# | 2 | 5 |
+# | 3 | 6 |
+# +---+---+
+
+# export to pandas dataframe
+pandas_df = df.to_pandas()
+assert pandas_df.shape == (3, 2)
+
+# export to PyArrow table
+arrow_table = df.to_arrow_table()
+assert arrow_table.shape == (3, 2)
+
+# export to Polars dataframe
+polars_df = pl.DataFrame(df.to_arrow_table())
+assert polars_df.shape == (3, 2)
+
+# export to Python list of rows
+pylist = df.to_pylist()
+assert pylist == [{"a": 1, "b": 4}, {"a": 2, "b": 5}, {"a": 3, "b": 6}]
+
+# export to Pyton dictionary of columns
+pydict = df.to_pydict()
+assert pydict == {"a": [1, 2, 3], "b": [4, 5, 6]}

--- a/src/dataframe.rs
+++ b/src/dataframe.rs
@@ -313,20 +313,56 @@ impl PyDataFrame {
         Ok(())
     }
 
-    /// Convert to pandas dataframe with pyarrow
-    /// Collect the batches, pass to Arrow Table & then convert to Pandas DataFrame
-    fn to_pandas(&self, py: Python) -> PyResult<PyObject> {
-        let batches = self.collect(py);
+    /// Convert to Arrow Table
+    /// Collect the batches and pass to Arrow Table
+    fn to_arrow_table(&self, py: Python) -> PyResult<PyObject> {
+        let batches = self.collect(py)?.to_object(py);
+        let schema: PyObject = self.schema().into_py(py);
 
         Python::with_gil(|py| {
             // Instantiate pyarrow Table object and use its from_batches method
             let table_class = py.import("pyarrow")?.getattr("Table")?;
-            let args = PyTuple::new(py, batches);
+            let args = PyTuple::new(py, &[batches, schema]);
             let table: PyObject = table_class.call_method1("from_batches", args)?.into();
+            Ok(table)
+        })
+    }
 
+    /// Convert to pandas dataframe with pyarrow
+    /// Collect the batches, pass to Arrow Table & then convert to Pandas DataFrame
+    fn to_pandas(&self, py: Python) -> PyResult<PyObject> {
+        let table = self.to_arrow_table(py)?;
+
+        Python::with_gil(|py| {
             // Use Table.to_pandas() method to convert batches to pandas dataframe
             // See also: https://arrow.apache.org/docs/python/generated/pyarrow.Table.html#pyarrow.Table.to_pandas
             let result = table.call_method0(py, "to_pandas")?;
+            Ok(result)
+        })
+    }
+
+    /// Convert to Python list using pyarrow
+    /// Each list item represents one row encoded as dictionary
+    fn to_pylist(&self, py: Python) -> PyResult<PyObject> {
+        let table = self.to_arrow_table(py)?;
+
+        Python::with_gil(|py| {
+            // Use Table.to_pylist() method to convert batches to pandas dataframe
+            // See also: https://arrow.apache.org/docs/python/generated/pyarrow.Table.html#pyarrow.Table.to_pylist
+            let result = table.call_method0(py, "to_pylist")?;
+            Ok(result)
+        })
+    }
+
+    /// Convert to Python dictionary using pyarrow
+    /// Each dictionary key is a column and the dictionary value represents the column values
+    fn to_pydict(&self, py: Python) -> PyResult<PyObject> {
+        let table = self.to_arrow_table(py)?;
+
+        Python::with_gil(|py| {
+            // Use Table.to_pydict() method to convert batches to pandas dataframe
+            // See also: https://arrow.apache.org/docs/python/generated/pyarrow.Table.html#pyarrow.Table.to_pydict
+            let result = table.call_method0(py, "to_pydict")?;
             Ok(result)
         })
     }

--- a/src/dataframe.rs
+++ b/src/dataframe.rs
@@ -334,7 +334,6 @@ impl PyDataFrame {
         let table = self.to_arrow_table(py)?;
 
         Python::with_gil(|py| {
-            // Use Table.to_pandas() method to convert batches to pandas dataframe
             // See also: https://arrow.apache.org/docs/python/generated/pyarrow.Table.html#pyarrow.Table.to_pandas
             let result = table.call_method0(py, "to_pandas")?;
             Ok(result)
@@ -347,7 +346,6 @@ impl PyDataFrame {
         let table = self.to_arrow_table(py)?;
 
         Python::with_gil(|py| {
-            // Use Table.to_pylist() method to convert batches to pandas dataframe
             // See also: https://arrow.apache.org/docs/python/generated/pyarrow.Table.html#pyarrow.Table.to_pylist
             let result = table.call_method0(py, "to_pylist")?;
             Ok(result)
@@ -360,7 +358,6 @@ impl PyDataFrame {
         let table = self.to_arrow_table(py)?;
 
         Python::with_gil(|py| {
-            // Use Table.to_pydict() method to convert batches to pandas dataframe
             // See also: https://arrow.apache.org/docs/python/generated/pyarrow.Table.html#pyarrow.Table.to_pydict
             let result = table.call_method0(py, "to_pydict")?;
             Ok(result)

--- a/src/dataframe.rs
+++ b/src/dataframe.rs
@@ -364,6 +364,19 @@ impl PyDataFrame {
         })
     }
 
+    /// Convert to polars dataframe with pyarrow
+    /// Collect the batches, pass to Arrow Table & then convert to polars DataFrame
+    fn to_polars(&self, py: Python) -> PyResult<PyObject> {
+        let table = self.to_arrow_table(py)?;
+
+        Python::with_gil(|py| {
+            let dataframe = py.import("polars")?.getattr("DataFrame")?;
+            let args = PyTuple::new(py, &[table]);
+            let result: PyObject = dataframe.call1(args)?.into();
+            Ok(result)
+        })
+    }
+
     // Executes this DataFrame to get the total number of rows.
     fn count(&self, py: Python) -> PyResult<usize> {
         Ok(wait_for_future(py, self.df.as_ref().clone().count())?)


### PR DESCRIPTION
# Which issue does this PR close?

Closes #234
Closes #235 

 # Rationale for this change
Implement additional export functions and fix bug if datafusion dataframe is empty

# What changes are included in this PR?
- Implement `to_arrow_table()`, `to_pylist()` and `to_pydict()`
- Return empty dataframe/list/table instead of error if datafusion dataframe is empty
- Document these export functions

# Are there any user-facing changes?
See above
