### PR TITLE
feature: Create dataframe from pandas, polars, dictionary, list or pyarrow Table

### DIFF
--- a/datafusion/tests/test_context.py
+++ b/datafusion/tests/test_context.py
@@ -95,6 +95,51 @@ def test_create_dataframe_registers_unique_table_name(ctx):
         assert c in "0123456789abcdef"
 
 
+def test_from_arrow_table(ctx):
+    # create a PyArrow table
+    data = {"a": [1, 2, 3], "b": [4, 5, 6]}
+    table = pa.Table.from_pydict(data)
+
+    # convert to DataFrame
+    df = ctx.from_arrow_table(table)
+    tables = list(ctx.tables())
+
+    assert df
+    assert len(tables) == 1
+    assert set(df.schema().names) == {"a", "b"}
+    assert df.collect()[0].num_rows == 3
+
+
+def test_from_pylist(ctx):
+    # create a dataframe from Python list
+    data = [
+        {"a": 1, "b": 4},
+        {"a": 2, "b": 5},
+        {"a": 3, "b": 6},
+    ]
+
+    df = ctx.from_pylist(data)
+    tables = list(ctx.tables())
+
+    assert df
+    assert len(tables) == 1
+    assert set(df.schema().names) == {"a", "b"}
+    assert df.collect()[0].num_rows == 3
+
+
+def test_from_pydict(ctx):
+    # create a dataframe from Python dictionary
+    data = {"a": [1, 2, 3], "b": [4, 5, 6]}
+
+    df = ctx.from_pydict(data)
+    tables = list(ctx.tables())
+
+    assert df
+    assert len(tables) == 1
+    assert set(df.schema().names) == {"a", "b"}
+    assert df.collect()[0].num_rows == 3
+
+
 def test_register_table(ctx, database):
     default = ctx.catalog()
     public = default.database("public")

--- a/datafusion/tests/test_context.py
+++ b/datafusion/tests/test_context.py
@@ -26,6 +26,7 @@ from datafusion import (
     SessionContext,
     SessionConfig,
     RuntimeConfig,
+    DataFrame,
 )
 import pytest
 
@@ -106,6 +107,7 @@ def test_from_arrow_table(ctx):
 
     assert df
     assert len(tables) == 1
+    assert type(df) == DataFrame
     assert set(df.schema().names) == {"a", "b"}
     assert df.collect()[0].num_rows == 3
 
@@ -123,6 +125,7 @@ def test_from_pylist(ctx):
 
     assert df
     assert len(tables) == 1
+    assert type(df) == DataFrame
     assert set(df.schema().names) == {"a", "b"}
     assert df.collect()[0].num_rows == 3
 
@@ -136,6 +139,39 @@ def test_from_pydict(ctx):
 
     assert df
     assert len(tables) == 1
+    assert type(df) == DataFrame
+    assert set(df.schema().names) == {"a", "b"}
+    assert df.collect()[0].num_rows == 3
+
+
+def test_from_pandas(ctx):
+    # create a dataframe from pandas dataframe
+    pd = pytest.importorskip("pandas")
+    data = {"a": [1, 2, 3], "b": [4, 5, 6]}
+    pandas_df = pd.DataFrame(data)
+
+    df = ctx.from_pandas(pandas_df)
+    tables = list(ctx.tables())
+
+    assert df
+    assert len(tables) == 1
+    assert type(df) == DataFrame
+    assert set(df.schema().names) == {"a", "b"}
+    assert df.collect()[0].num_rows == 3
+
+
+def test_from_polars(ctx):
+    # create a dataframe from Polars dataframe
+    pd = pytest.importorskip("polars")
+    data = {"a": [1, 2, 3], "b": [4, 5, 6]}
+    polars_df = pd.DataFrame(data)
+
+    df = ctx.from_polars(polars_df)
+    tables = list(ctx.tables())
+
+    assert df
+    assert len(tables) == 1
+    assert type(df) == DataFrame
     assert set(df.schema().names) == {"a", "b"}
     assert df.collect()[0].num_rows == 3
 

--- a/examples/export.py
+++ b/examples/export.py
@@ -16,18 +16,13 @@
 # under the License.
 
 import datafusion
-import pyarrow
 
 
 # create a context
 ctx = datafusion.SessionContext()
 
-# create a RecordBatch and a new datafusion DataFrame from it
-batch = pyarrow.RecordBatch.from_arrays(
-    [pyarrow.array([1, 2, 3]), pyarrow.array([4, 5, 6])],
-    names=["a", "b"],
-)
-df = ctx.create_dataframe([[batch]])
+# create a new datafusion DataFrame
+df = ctx.from_pydict({"a": [1, 2, 3], "b": [4, 5, 6]})
 # Dataframe:
 # +---+---+
 # | a | b |

--- a/examples/import.py
+++ b/examples/import.py
@@ -1,0 +1,58 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import datafusion
+import pyarrow as pa
+import pandas as pd
+import polars as pl
+
+
+# Create a context
+ctx = datafusion.SessionContext()
+
+# Create a datafusion DataFrame from a Python dictionary
+# The dictionary keys represent column names and the dictionary values
+# represent column values
+df = ctx.from_pydict({"a": [1, 2, 3], "b": [4, 5, 6]})
+assert type(df) == datafusion.DataFrame
+# Dataframe:
+# +---+---+
+# | a | b |
+# +---+---+
+# | 1 | 4 |
+# | 2 | 5 |
+# | 3 | 6 |
+# +---+---+
+
+# Create a datafusion DataFrame from a Python list of rows
+df = ctx.from_pylist([{"a": 1, "b": 4}, {"a": 2, "b": 5}, {"a": 3, "b": 6}])
+assert type(df) == datafusion.DataFrame
+
+# Convert pandas DataFrame to datafusion DataFrame
+pandas_df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+df = ctx.from_pandas(pandas_df)
+assert type(df) == datafusion.DataFrame
+
+# Convert polars DataFrame to datafusion DataFrame
+polars_df = pl.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+df = ctx.from_polars(polars_df)
+assert type(df) == datafusion.DataFrame
+
+# Convert Arrow Table to datafusion DataFrame
+arrow_table = pa.Table.from_pydict({"a": [1, 2, 3], "b": [4, 5, 6]})
+df = ctx.from_arrow_table(arrow_table)
+assert type(df) == datafusion.DataFrame

--- a/src/context.rs
+++ b/src/context.rs
@@ -304,6 +304,7 @@ impl PySessionContext {
     }
 
     /// Construct datafusion dataframe from Python list
+    #[allow(clippy::wrong_self_convention)]
     fn from_pylist(&mut self, data: PyObject, _py: Python) -> PyResult<PyDataFrame> {
         Python::with_gil(|py| {
             // Instantiate pyarrow Table object & convert to Arrow Table
@@ -318,6 +319,7 @@ impl PySessionContext {
     }
 
     /// Construct datafusion dataframe from Python dictionary
+    #[allow(clippy::wrong_self_convention)]
     fn from_pydict(&mut self, data: PyObject, _py: Python) -> PyResult<PyDataFrame> {
         Python::with_gil(|py| {
             // Instantiate pyarrow Table object & convert to Arrow Table
@@ -332,6 +334,7 @@ impl PySessionContext {
     }
 
     /// Construct datafusion dataframe from Arrow Table
+    #[allow(clippy::wrong_self_convention)]
     fn from_arrow_table(&mut self, data: PyObject, _py: Python) -> PyResult<PyDataFrame> {
         Python::with_gil(|py| {
             // Instantiate pyarrow Table object & convert to batches
@@ -347,6 +350,7 @@ impl PySessionContext {
     }
 
     /// Construct datafusion dataframe from pandas
+    #[allow(clippy::wrong_self_convention)]
     fn from_pandas(&mut self, data: PyObject, _py: Python) -> PyResult<PyDataFrame> {
         Python::with_gil(|py| {
             // Instantiate pyarrow Table object & convert to Arrow Table
@@ -361,10 +365,11 @@ impl PySessionContext {
     }
 
     /// Construct datafusion dataframe from polars
+    #[allow(clippy::wrong_self_convention)]
     fn from_polars(&mut self, data: PyObject, _py: Python) -> PyResult<PyDataFrame> {
         Python::with_gil(|py| {
             // Convert Polars dataframe to Arrow Table
-            let table = data.call_method0(py, "to_arrow")?.into();
+            let table = data.call_method0(py, "to_arrow")?;
 
             // Convert Arrow Table to datafusion DataFrame
             let df = self.from_arrow_table(table, py)?;


### PR DESCRIPTION
# Which issue does this PR close?

Closes #241.

 # Rationale for this change
Better integration with Python language & popular libraries

# What changes are included in this PR?
- Implement functions that construct datafusion DataFrames:
   - [x] from_pydict
   - [x] from_pylist
   - [x] from_pandas
   - [x] from_polars
   - [x] from_arrow_table
- Document new functions

# Are there any user-facing changes?
New context functions listed above
