### PR TITLE
minor: Fix minor warning on unused import

### DIFF
--- a/src/expr/literal.rs
+++ b/src/expr/literal.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::errors::{py_runtime_err, DataFusionError};
+use crate::errors::DataFusionError;
 use datafusion_common::ScalarValue;
 use pyo3::prelude::*;
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Got a warning when verifying 20.0.0 RC 2 release:
```
warning: unused import: `py_runtime_err` 386/387: datafusion-python                                                                                                                                                                  
  --> src/expr/literal.rs:18:21
   |
18 | use crate::errors::{py_runtime_err, DataFusionError};
   |                     ^^^^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default


warning: 1 warning emitted===========> ] 386/387: datafusion-python                                                                                                                                                                  
```

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->