### PR TITLE
Add interface to serialize Substrait plans to Python Bytes.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -899,6 +899,8 @@ dependencies = [
  "mimalloc",
  "object_store",
  "parking_lot",
+ "prost",
+ "prost-types",
  "pyo3",
  "pyo3-build-config",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,8 @@ datafusion-expr = "23.0.0"
 datafusion-optimizer = "23.0.0"
 datafusion-sql = "23.0.0"
 datafusion-substrait = "23.0.0"
+prost = "0.11"
+prost-types = "0.11"
 uuid = { version = "1.2", features = ["v4"] }
 mimalloc = { version = "0.1", optional = true, default-features = false }
 async-trait = "0.1"

--- a/datafusion/tests/test_substrait.py
+++ b/datafusion/tests/test_substrait.py
@@ -41,6 +41,8 @@ def test_substrait_serialization(ctx):
     substrait_plan = ss.substrait.serde.serialize_to_plan(
         "SELECT * FROM t", ctx
     )
+    substrait_bytes = substrait_plan.encode()
+    assert type(substrait_bytes) is bytes
     substrait_bytes = ss.substrait.serde.serialize_bytes(
         "SELECT * FROM t", ctx
     )

--- a/examples/substrait.py
+++ b/examples/substrait.py
@@ -32,8 +32,13 @@ substrait_plan = ss.substrait.serde.serialize_to_plan(
 )
 # type(substrait_plan) -> <class 'datafusion.substrait.plan'>
 
+# Encode it to bytes
+substrait_bytes = substrait_plan.encode()
+# type(substrait_bytes) -> <class 'bytes'>, at this point the bytes can be distributed to file, network, etc safely
+# where they could subsequently be deserialized on the receiving end.
+
 # Alternative serialization approaches
-# type(substrait_bytes) -> <class 'list'>, at this point the bytes can be distributed to file, network, etc safely
+# type(substrait_bytes) -> <class 'bytes'>, at this point the bytes can be distributed to file, network, etc safely
 # where they could subsequently be deserialized on the receiving end.
 substrait_bytes = ss.substrait.serde.serialize_bytes(
     "SELECT * FROM aggregate_test_data", ctx

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -21,6 +21,7 @@ use std::fmt::Debug;
 
 use datafusion::arrow::error::ArrowError;
 use datafusion::error::DataFusionError as InnerDataFusionError;
+use prost::EncodeError;
 use pyo3::{exceptions::PyException, PyErr};
 
 pub type Result<T> = std::result::Result<T, DataFusionError>;
@@ -31,6 +32,7 @@ pub enum DataFusionError {
     ArrowError(ArrowError),
     Common(String),
     PythonError(PyErr),
+    EncodeError(EncodeError),
 }
 
 impl fmt::Display for DataFusionError {
@@ -40,6 +42,7 @@ impl fmt::Display for DataFusionError {
             DataFusionError::ArrowError(e) => write!(f, "Arrow error: {e:?}"),
             DataFusionError::PythonError(e) => write!(f, "Python error {e:?}"),
             DataFusionError::Common(e) => write!(f, "{e}"),
+            DataFusionError::EncodeError(e) => write!(f, "Failed to encode substrait plan: {e}"),
         }
     }
 }


### PR DESCRIPTION
Also, Clean up existing Substrait bindings to return bytes instead of List[int].

# Which issue does this PR close?

Closes #343 

 # Rationale for this change
What we had before didn't allow for serializing a Substrait plan to ProtoBuf. You had to use a SQL query which was awkward. This also fixes the `substrait` module return types to be `bytes` instead of `List[int]` which is also awkward.

# What changes are included in this PR?
Add `encode` method to `datafusion.substrait.plan`. Also change datafusion.substrait return types to be `bytes` instead of `List[int]`.

# Are there any user-facing changes?
Yes, but IMO changes for the better.
