### PR TITLE
Update conda build/host deps to avoid overlinking issues

### DIFF
--- a/conda/recipes/conda_build_config.yaml
+++ b/conda/recipes/conda_build_config.yaml
@@ -1,0 +1,4 @@
+rust_compiler_version:
+    - 1.64
+libprotobuf:
+    - 3

--- a/conda/recipes/meta.yaml
+++ b/conda/recipes/meta.yaml
@@ -34,11 +34,15 @@ build:
   number: 0
 
 requirements:
+  build:
+    - {{ compiler('rust') }}
+    - {{ compiler('c') }}  # [linux]
   host:
     - python >=3.7
     - maturin >=0.15,<0.16
     - libprotobuf =3
     - pip
+    - xz  # [linux]
   run:
     - python >=3.7
     - pyarrow >=11.0.0

--- a/conda/recipes/meta.yaml
+++ b/conda/recipes/meta.yaml
@@ -35,13 +35,16 @@ build:
 
 requirements:
   build:
+    - libprotobuf             # [build_platform != target_platform]
+    - zlib                    # [build_platform != target_platform]
     - {{ compiler('rust') }}
-    - {{ compiler('c') }}  # [linux]
+    - {{ compiler('c') }}     # [linux]
   host:
     - python >=3.7
     - maturin >=0.15,<0.16
-    - libprotobuf =3
+    - libprotobuf
     - pip
+    - zlib
     - xz  # [linux]
   run:
     - python >=3.7


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

n/a

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Our conda nightly builds emit some warnings around overlinking:

```
WARNING (datafusion,lib/python3.11/site-packages/datafusion/_internal.abi3.so): Needed DSO lib/liblzma.so.5 found in ['xz']
WARNING (datafusion,lib/python3.11/site-packages/datafusion/_internal.abi3.so): .. but ['xz'] not in reqs/run, (i.e. it is overlinking) (likely) or a missing dependency (less likely)
WARNING (datafusion,lib/python3.11/site-packages/datafusion/_internal.abi3.so): Needed DSO lib/libgcc_s.so.1 found in ['libgcc-ng']
WARNING (datafusion,lib/python3.11/site-packages/datafusion/_internal.abi3.so): .. but ['libgcc-ng'] not in reqs/run, (i.e. it is overlinking) (likely) or a missing dependency (less likely)
```

That seem to be due to leaving out some build/host requirements that should be explicitly specified. This PR does this using the same approach taken in https://github.com/conda-forge/staged-recipes/pull/23386 to resolve overlinking issues in a similar maturin project.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Adds Rust / C compilers to build deps to resolve the `libgcc_s.so.1` dependency, and `xz` to the host deps to resolve the `liblzma.so.5` dependency 

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

n/a

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->