### PR TITLE
Update build.yml to support Linux ARM 64 on Github CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -151,6 +151,37 @@ jobs:
           name: dist
           path: target/wheels/*
 
+
+  build-manylinux-aarch64:
+    needs: [ generate-license ]
+    name: Manylinux ARM64
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: rm LICENSE.txt
+      - name: Download LICENSE.txt
+        uses: actions/download-artifact@v3
+        with:
+          name: python-wheel-license
+          path: .
+      - run: cat LICENSE.txt
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          rust-toolchain: nightly
+          target: aarch64
+          manylinux: auto
+          rustup-components: rust-std rustfmt # Keep them in one line due to https://github.com/PyO3/maturin-action/issues/153
+          args: --release --manylinux 2014 --features protoc
+      - name: Archive wheels
+        uses: actions/upload-artifact@v3
+        with:
+          name: dist
+          path: target/wheels/*
+
+
   build-manylinux:
     needs: [generate-license]
     name: Manylinux

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -167,6 +167,8 @@ jobs:
       - run: cat LICENSE.txt
       - name: Setup QEMU
         uses: docker/setup-qemu-action@v1
+      - name: Install cross-compiler dependencies
+        run: sudo apt-get update && sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/arrow-datafusion-python/issues/426

# Rationale for this change
The need for this change arises due to the prolonged build times experienced with linux arm64 docker, especially on macOS during the prototyping phase.

# What changes are included in this PR?
In this PR, an emulator for Linux arm64 is included, as GitHub does not natively provide one.

BTW, I am not sure how to test this, if a PMC could help, that would be perfect.

# Are there any user-facing changes?
No