### PR TITLE
Build Linux aarch64 wheel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -203,7 +203,7 @@ jobs:
           # Use manylinux_2_28-cross because the manylinux2014-cross has GCC 4.8.5, which causes the build to fail
           manylinux: 2_28
           rustup-components: rust-std rustfmt # Keep them in one line due to https://github.com/PyO3/maturin-action/issues/153
-          args: --release --manylinux 2_28 --features protoc
+          args: --release --features protoc
       - name: Archive wheels
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -180,6 +180,36 @@ jobs:
           name: dist
           path: target/wheels/*
 
+  build-manylinux-aarch64:
+    needs: [generate-license]
+    name: Manylinux arm64
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: rm LICENSE.txt
+      - name: Download LICENSE.txt
+        uses: actions/download-artifact@v3
+        with:
+          name: python-wheel-license
+          path: .
+      - run: cat LICENSE.txt
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        env:
+          RUST_BACKTRACE: 1
+        with:
+          rust-toolchain: nightly
+          target: aarch64
+          # Use manylinux_2_28-cross because the manylinux2014-cross has GCC 4.8.5, which causes the build to fail
+          manylinux: 2_28
+          rustup-components: rust-std rustfmt # Keep them in one line due to https://github.com/PyO3/maturin-action/issues/153
+          args: --release --manylinux 2_28 --features protoc
+      - name: Archive wheels
+        uses: actions/upload-artifact@v3
+        with:
+          name: dist
+          path: target/wheels/*
+
   build-sdist:
     needs: [generate-license]
     name: Source distribution


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #426.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

As a user on a Linux aarch64 (ARM64) system, I have faced challenges when trying to install DataFusion from pip. Currently, the pre-built wheel is only available for x86_64 architecture on Linux, leaving ARM-based systems unsupported. To address this issue and enhance the usability of DataFusion in ARM environments, I propose the inclusion of a pre-built DataFusion wheel specifically for Linux aarch64.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

This PR includes the addition of a pre-built DataFusion wheel for Linux aarch64 (ARM64) architecture, making it easier for users to install DataFusion on ARM-based systems without the need to build it from source.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

No, there are no user-facing changes in this PR. The introduction of the pre-built wheel is meant to simplify the installation process for Linux aarch64 users without affecting the overall user experience.