### PR TITLE
feat: expose PyWindowFrame

### DIFF
--- a/datafusion/__init__.py
+++ b/datafusion/__init__.py
@@ -33,6 +33,7 @@ from ._internal import (
     SessionConfig,
     RuntimeConfig,
     ScalarUDF,
+    WindowFrame,
 )
 
 from .common import (
@@ -98,6 +99,7 @@ __all__ = [
     "Expr",
     "AggregateUDF",
     "ScalarUDF",
+    "WindowFrame",
     "column",
     "literal",
     "TableScan",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,7 @@ mod udaf;
 #[allow(clippy::borrow_deref_ref)]
 mod udf;
 pub mod utils;
+mod window_frame;
 
 #[cfg(feature = "mimalloc")]
 #[global_allocator]
@@ -83,6 +84,7 @@ fn _internal(py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<context::PySessionContext>()?;
     m.add_class::<dataframe::PyDataFrame>()?;
     m.add_class::<udf::PyScalarUDF>()?;
+    m.add_class::<window_frame::PyWindowFrame>()?;
     m.add_class::<udaf::PyAggregateUDF>()?;
     m.add_class::<config::PyConfig>()?;
     m.add_class::<sql::logical::PyLogicalPlan>()?;

--- a/src/window_frame.rs
+++ b/src/window_frame.rs
@@ -1,0 +1,93 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use datafusion_common::ScalarValue;
+use datafusion_expr::window_frame::{WindowFrame, WindowFrameBound, WindowFrameUnits};
+use pyo3::prelude::*;
+use std::fmt::{Display, Formatter};
+
+#[pyclass(name = "WindowFrame", module = "datafusion", subclass)]
+#[derive(Clone)]
+pub struct PyWindowFrame {
+    frame: WindowFrame,
+}
+
+impl From<PyWindowFrame> for WindowFrame {
+    fn from(frame: PyWindowFrame) -> Self {
+        frame.frame
+    }
+}
+
+impl From<WindowFrame> for PyWindowFrame {
+    fn from(frame: WindowFrame) -> PyWindowFrame {
+        PyWindowFrame { frame }
+    }
+}
+
+impl Display for PyWindowFrame {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "OVER ({} BETWEEN {} AND {})",
+            self.frame.units, self.frame.start_bound, self.frame.end_bound
+        )
+    }
+}
+
+#[pymethods]
+impl PyWindowFrame {
+    #[new(unit, start_bound, end_bound)]
+    pub fn new(units: &str, start_bound: Option<u64>, end_bound: Option<u64>) -> PyResult<Self> {
+        let units = match units.to_ascii_lowercase().as_str() {
+            "rows" => Some(WindowFrameUnits::Rows),
+            "range" => Some(WindowFrameUnits::Range),
+            "groups" => Some(WindowFrameUnits::Groups),
+            _ => None,
+        };
+        let units = units.unwrap();
+        let start_bound = match start_bound {
+            Some(start_bound) => {
+                WindowFrameBound::Preceding(ScalarValue::UInt64(Some(start_bound)))
+            }
+            None => match units {
+                WindowFrameUnits::Range => WindowFrameBound::Preceding(ScalarValue::UInt64(None)),
+                WindowFrameUnits::Rows => WindowFrameBound::Preceding(ScalarValue::UInt64(None)),
+                WindowFrameUnits::Groups => todo!(),
+            },
+        };
+        let end_bound = match end_bound {
+            Some(end_bound) => WindowFrameBound::Following(ScalarValue::UInt64(Some(end_bound))),
+            None => match units {
+                WindowFrameUnits::Rows => WindowFrameBound::Following(ScalarValue::UInt64(None)),
+                WindowFrameUnits::Range => WindowFrameBound::Following(ScalarValue::UInt64(None)),
+                WindowFrameUnits::Groups => todo!(),
+            },
+        };
+        Ok(PyWindowFrame {
+            frame: WindowFrame {
+                units,
+                start_bound,
+                end_bound,
+            },
+        })
+    }
+
+    /// Get a String representation of this window frame
+    fn __repr__(&self) -> String {
+        format!("{}", self)
+    }
+}


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Partial progress on #191 : Expressions: Window function

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

This PR
- adds `PyWindowFrame`
- modifies `functions.window` to accept an optional `PyWindowFrame` and optional `PySessionContext`
  - `PySessionContext` is necessary to look up aggregates registered via `PySessionContext.register_udaf`
- modifies `function.window` to fall back to `SessionContext.udaf` when `find_df_window_func` fails
- modifies `Accumulator` impl for `RustAccumulator` to expose `retract_batch` and `supports_retract_batch`

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
`PyWindowFrame` needs to be documented as do changes to `functions.window` 

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

note: I have working code that enables window functions for `ibis` that I still need to create a PR for