### PR TITLE
Adjust visibility of crate private members & Functions

### DIFF
--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -30,18 +30,18 @@ use datafusion::{
 };
 
 #[pyclass(name = "Catalog", module = "datafusion", subclass)]
-pub(crate) struct PyCatalog {
-    catalog: Arc<dyn CatalogProvider>,
+pub struct PyCatalog {
+    pub catalog: Arc<dyn CatalogProvider>,
 }
 
 #[pyclass(name = "Database", module = "datafusion", subclass)]
-pub(crate) struct PyDatabase {
-    database: Arc<dyn SchemaProvider>,
+pub struct PyDatabase {
+    pub database: Arc<dyn SchemaProvider>,
 }
 
 #[pyclass(name = "Table", module = "datafusion", subclass)]
 pub struct PyTable {
-    table: Arc<dyn TableProvider>,
+    pub table: Arc<dyn TableProvider>,
 }
 
 impl PyCatalog {

--- a/src/common/df_field.rs
+++ b/src/common/df_field.rs
@@ -27,7 +27,7 @@ use super::data_type::PyDataType;
 #[pyclass(name = "DFField", module = "datafusion.common", subclass)]
 #[derive(Debug, Clone)]
 pub struct PyDFField {
-    field: DFField,
+    pub field: DFField,
 }
 
 impl From<PyDFField> for DFField {

--- a/src/context.rs
+++ b/src/context.rs
@@ -60,8 +60,8 @@ use tokio::task::JoinHandle;
 /// Configuration options for a SessionContext
 #[pyclass(name = "SessionConfig", module = "datafusion", subclass)]
 #[derive(Clone, Default)]
-pub(crate) struct PySessionConfig {
-    pub(crate) config: SessionConfig,
+pub struct PySessionConfig {
+    pub config: SessionConfig,
 }
 
 impl From<SessionConfig> for PySessionConfig {
@@ -153,8 +153,8 @@ impl PySessionConfig {
 /// Runtime options for a SessionContext
 #[pyclass(name = "RuntimeConfig", module = "datafusion", subclass)]
 #[derive(Clone)]
-pub(crate) struct PyRuntimeConfig {
-    pub(crate) config: RuntimeConfig,
+pub struct PyRuntimeConfig {
+    pub config: RuntimeConfig,
 }
 
 #[pymethods]
@@ -215,15 +215,15 @@ impl PyRuntimeConfig {
 /// multi-threaded execution engine to perform the execution.
 #[pyclass(name = "SessionContext", module = "datafusion", subclass)]
 #[derive(Clone)]
-pub(crate) struct PySessionContext {
-    pub(crate) ctx: SessionContext,
+pub struct PySessionContext {
+    pub ctx: SessionContext,
 }
 
 #[pymethods]
 impl PySessionContext {
     #[pyo3(signature = (config=None, runtime=None))]
     #[new]
-    fn new(config: Option<PySessionConfig>, runtime: Option<PyRuntimeConfig>) -> PyResult<Self> {
+    pub fn new(config: Option<PySessionConfig>, runtime: Option<PyRuntimeConfig>) -> PyResult<Self> {
         let config = if let Some(c) = config {
             c.config
         } else {
@@ -242,7 +242,7 @@ impl PySessionContext {
     }
 
     /// Register a an object store with the given name
-    fn register_object_store(
+    pub fn register_object_store(
         &mut self,
         scheme: &str,
         store: &PyAny,
@@ -276,13 +276,13 @@ impl PySessionContext {
     }
 
     /// Returns a PyDataFrame whose plan corresponds to the SQL statement.
-    fn sql(&mut self, query: &str, py: Python) -> PyResult<PyDataFrame> {
+    pub fn sql(&mut self, query: &str, py: Python) -> PyResult<PyDataFrame> {
         let result = self.ctx.sql(query);
         let df = wait_for_future(py, result).map_err(DataFusionError::from)?;
         Ok(PyDataFrame::new(df))
     }
 
-    fn create_dataframe(
+    pub fn create_dataframe(
         &mut self,
         partitions: PyArrowType<Vec<Vec<RecordBatch>>>,
         name: Option<&str>,
@@ -314,13 +314,13 @@ impl PySessionContext {
     }
 
     /// Create a DataFrame from an existing logical plan
-    fn create_dataframe_from_logical_plan(&mut self, plan: PyLogicalPlan) -> PyDataFrame {
+    pub fn create_dataframe_from_logical_plan(&mut self, plan: PyLogicalPlan) -> PyDataFrame {
         PyDataFrame::new(DataFrame::new(self.ctx.state(), plan.plan.as_ref().clone()))
     }
 
     /// Construct datafusion dataframe from Python list
     #[allow(clippy::wrong_self_convention)]
-    fn from_pylist(
+    pub fn from_pylist(
         &mut self,
         data: PyObject,
         name: Option<&str>,
@@ -340,7 +340,7 @@ impl PySessionContext {
 
     /// Construct datafusion dataframe from Python dictionary
     #[allow(clippy::wrong_self_convention)]
-    fn from_pydict(
+    pub fn from_pydict(
         &mut self,
         data: PyObject,
         name: Option<&str>,
@@ -360,7 +360,7 @@ impl PySessionContext {
 
     /// Construct datafusion dataframe from Arrow Table
     #[allow(clippy::wrong_self_convention)]
-    fn from_arrow_table(
+    pub fn from_arrow_table(
         &mut self,
         data: PyObject,
         name: Option<&str>,
@@ -381,7 +381,7 @@ impl PySessionContext {
 
     /// Construct datafusion dataframe from pandas
     #[allow(clippy::wrong_self_convention)]
-    fn from_pandas(
+    pub fn from_pandas(
         &mut self,
         data: PyObject,
         name: Option<&str>,
@@ -401,7 +401,7 @@ impl PySessionContext {
 
     /// Construct datafusion dataframe from polars
     #[allow(clippy::wrong_self_convention)]
-    fn from_polars(
+    pub fn from_polars(
         &mut self,
         data: PyObject,
         name: Option<&str>,
@@ -417,21 +417,21 @@ impl PySessionContext {
         })
     }
 
-    fn register_table(&mut self, name: &str, table: &PyTable) -> PyResult<()> {
+    pub fn register_table(&mut self, name: &str, table: &PyTable) -> PyResult<()> {
         self.ctx
             .register_table(name, table.table())
             .map_err(DataFusionError::from)?;
         Ok(())
     }
 
-    fn deregister_table(&mut self, name: &str) -> PyResult<()> {
+    pub fn deregister_table(&mut self, name: &str) -> PyResult<()> {
         self.ctx
             .deregister_table(name)
             .map_err(DataFusionError::from)?;
         Ok(())
     }
 
-    fn register_record_batches(
+    pub fn register_record_batches(
         &mut self,
         name: &str,
         partitions: PyArrowType<Vec<Vec<RecordBatch>>>,
@@ -451,7 +451,7 @@ impl PySessionContext {
                         skip_metadata=true,
                         schema=None,
                         file_sort_order=None))]
-    fn register_parquet(
+    pub fn register_parquet(
         &mut self,
         name: &str,
         path: &str,
@@ -489,7 +489,7 @@ impl PySessionContext {
                         schema_infer_max_records=1000,
                         file_extension=".csv",
                         file_compression_type=None))]
-    fn register_csv(
+    pub fn register_csv(
         &mut self,
         name: &str,
         path: PathBuf,
@@ -533,7 +533,7 @@ impl PySessionContext {
                         file_extension=".json",
                         table_partition_cols=vec![],
                         file_compression_type=None))]
-    fn register_json(
+    pub fn register_json(
         &mut self,
         name: &str,
         path: PathBuf,
@@ -568,7 +568,7 @@ impl PySessionContext {
                         file_extension=".avro",
                         table_partition_cols=vec![],
                         infinite=false))]
-    fn register_avro(
+    pub fn register_avro(
         &mut self,
         name: &str,
         path: PathBuf,
@@ -595,7 +595,7 @@ impl PySessionContext {
     }
 
     // Registers a PyArrow.Dataset
-    fn register_dataset(&self, name: &str, dataset: &PyAny, py: Python) -> PyResult<()> {
+    pub fn register_dataset(&self, name: &str, dataset: &PyAny, py: Python) -> PyResult<()> {
         let table: Arc<dyn TableProvider> = Arc::new(Dataset::new(dataset, py)?);
 
         self.ctx
@@ -605,18 +605,18 @@ impl PySessionContext {
         Ok(())
     }
 
-    fn register_udf(&mut self, udf: PyScalarUDF) -> PyResult<()> {
+    pub fn register_udf(&mut self, udf: PyScalarUDF) -> PyResult<()> {
         self.ctx.register_udf(udf.function);
         Ok(())
     }
 
-    fn register_udaf(&mut self, udaf: PyAggregateUDF) -> PyResult<()> {
+    pub fn register_udaf(&mut self, udaf: PyAggregateUDF) -> PyResult<()> {
         self.ctx.register_udaf(udaf.function);
         Ok(())
     }
 
     #[pyo3(signature = (name="datafusion"))]
-    fn catalog(&self, name: &str) -> PyResult<PyCatalog> {
+    pub fn catalog(&self, name: &str) -> PyResult<PyCatalog> {
         match self.ctx.catalog(name) {
             Some(catalog) => Ok(PyCatalog::new(catalog)),
             None => Err(PyKeyError::new_err(format!(
@@ -626,31 +626,31 @@ impl PySessionContext {
         }
     }
 
-    fn tables(&self) -> HashSet<String> {
+    pub fn tables(&self) -> HashSet<String> {
         #[allow(deprecated)]
         self.ctx.tables().unwrap()
     }
 
-    fn table(&self, name: &str, py: Python) -> PyResult<PyDataFrame> {
+    pub fn table(&self, name: &str, py: Python) -> PyResult<PyDataFrame> {
         let x = wait_for_future(py, self.ctx.table(name)).map_err(DataFusionError::from)?;
         Ok(PyDataFrame::new(x))
     }
 
-    fn table_exist(&self, name: &str) -> PyResult<bool> {
+    pub fn table_exist(&self, name: &str) -> PyResult<bool> {
         Ok(self.ctx.table_exist(name)?)
     }
 
-    fn empty_table(&self) -> PyResult<PyDataFrame> {
+    pub fn empty_table(&self) -> PyResult<PyDataFrame> {
         Ok(PyDataFrame::new(self.ctx.read_empty()?))
     }
 
-    fn session_id(&self) -> String {
+    pub fn session_id(&self) -> String {
         self.ctx.session_id()
     }
 
     #[allow(clippy::too_many_arguments)]
     #[pyo3(signature = (path, schema=None, schema_infer_max_records=1000, file_extension=".json", table_partition_cols=vec![], file_compression_type=None))]
-    fn read_json(
+    pub fn read_json(
         &mut self,
         path: PathBuf,
         schema: Option<PyArrowType<Schema>>,
@@ -689,7 +689,7 @@ impl PySessionContext {
         file_extension=".csv",
         table_partition_cols=vec![],
         file_compression_type=None))]
-    fn read_csv(
+    pub fn read_csv(
         &self,
         path: PathBuf,
         schema: Option<PyArrowType<Schema>>,
@@ -741,7 +741,7 @@ impl PySessionContext {
         skip_metadata=true,
         schema=None,
         file_sort_order=None))]
-    fn read_parquet(
+    pub fn read_parquet(
         &self,
         path: &str,
         table_partition_cols: Vec<(String, String)>,
@@ -771,7 +771,7 @@ impl PySessionContext {
 
     #[allow(clippy::too_many_arguments)]
     #[pyo3(signature = (path, schema=None, table_partition_cols=vec![], file_extension=".avro"))]
-    fn read_avro(
+    pub fn read_avro(
         &self,
         path: &str,
         schema: Option<PyArrowType<Schema>>,
@@ -793,7 +793,7 @@ impl PySessionContext {
         Ok(PyDataFrame::new(df))
     }
 
-    fn read_table(&self, table: &PyTable) -> PyResult<PyDataFrame> {
+    pub fn read_table(&self, table: &PyTable) -> PyResult<PyDataFrame> {
         let df = self
             .ctx
             .read_table(table.table())

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -128,6 +128,7 @@ impl PyExpr {
             Expr::ScalarVariable(data_type, variables) => {
                 Ok(PyScalarVariable::new(data_type, variables).into_py(py))
             }
+            Expr::Like(value) => Ok(PyLike::from(value.clone()).into_py(py)),
             Expr::Literal(value) => Ok(PyLiteral::from(value.clone()).into_py(py)),
             Expr::BinaryExpr(expr) => Ok(PyBinaryExpr::from(expr.clone()).into_py(py)),
             Expr::Not(expr) => Ok(PyNot::new(*expr.clone()).into_py(py)),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@ pub mod common;
 #[allow(clippy::borrow_deref_ref)]
 mod config;
 #[allow(clippy::borrow_deref_ref)]
-mod context;
+pub mod context;
 #[allow(clippy::borrow_deref_ref)]
 mod dataframe;
 mod dataset;

--- a/src/substrait.rs
+++ b/src/substrait.rs
@@ -29,8 +29,8 @@ use prost::Message;
 
 #[pyclass(name = "plan", module = "datafusion.substrait", subclass)]
 #[derive(Debug, Clone)]
-pub(crate) struct PyPlan {
-    pub(crate) plan: Plan,
+pub struct PyPlan {
+    pub plan: Plan,
 }
 
 #[pymethods]
@@ -61,7 +61,7 @@ impl From<Plan> for PyPlan {
 /// to a valid `LogicalPlan` instance.
 #[pyclass(name = "serde", module = "datafusion.substrait", subclass)]
 #[derive(Debug, Clone)]
-pub(crate) struct PySubstraitSerializer;
+pub struct PySubstraitSerializer;
 
 #[pymethods]
 impl PySubstraitSerializer {
@@ -107,7 +107,7 @@ impl PySubstraitSerializer {
 
 #[pyclass(name = "producer", module = "datafusion.substrait", subclass)]
 #[derive(Debug, Clone)]
-pub(crate) struct PySubstraitProducer;
+pub struct PySubstraitProducer;
 
 #[pymethods]
 impl PySubstraitProducer {
@@ -123,7 +123,7 @@ impl PySubstraitProducer {
 
 #[pyclass(name = "consumer", module = "datafusion.substrait", subclass)]
 #[derive(Debug, Clone)]
-pub(crate) struct PySubstraitConsumer;
+pub struct PySubstraitConsumer;
 
 #[pymethods]
 impl PySubstraitConsumer {
@@ -140,7 +140,7 @@ impl PySubstraitConsumer {
     }
 }
 
-pub(crate) fn init_module(m: &PyModule) -> PyResult<()> {
+pub fn init_module(m: &PyModule) -> PyResult<()> {
     m.add_class::<PyPlan>()?;
     m.add_class::<PySubstraitConsumer>()?;
     m.add_class::<PySubstraitProducer>()?;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -25,7 +25,17 @@ use tokio::runtime::Runtime;
 /// Utility to get the Tokio Runtime from Python
 pub(crate) fn get_tokio_runtime(py: Python) -> PyRef<TokioRuntime> {
     let datafusion = py.import("datafusion._internal").unwrap();
-    datafusion.getattr("runtime").unwrap().extract().unwrap()
+    let tmp = datafusion.getattr("runtime").unwrap();
+    match tmp.extract::<PyRef<TokioRuntime>>() {
+        Ok(runtime) => {
+            runtime
+        },
+        Err(_e) => {
+            let rt = TokioRuntime(tokio::runtime::Runtime::new().unwrap());
+            let obj: &PyAny = Py::new(py, rt).unwrap().into_ref(py);
+            obj.extract().unwrap()
+        }
+    }
 }
 
 /// Utility to collect rust futures with GIL released


### PR DESCRIPTION
There are several places in the codebase that maintain `(crate)` visibility. This is generally fine but since ADP is generally used by third party libraries that does not make much sense since this prevents those libraries from using those entities. This PR adjusts a few that I have stumbled across and that have been causing problems for dask-sql.