### PR TITLE
Enable mimalloc local_dynamic_tls feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ datafusion-substrait = { version = "33.0.0", optional = true }
 prost = "0.12"
 prost-types = "0.12"
 uuid = { version = "1.3", features = ["v4"] }
-mimalloc = { version = "0.1", optional = true, default-features = false }
+mimalloc = { version = "0.1", optional = true, default-features = false, features = ["local_dynamic_tls"] }
 async-trait = "0.1"
 futures = "0.3"
 object_store = { version = "0.7.0", features = ["aws", "gcp", "azure"] }


### PR DESCRIPTION
We have been experiencing issues in dask-sql with dynamic TLS allocation when building on linux and targeting aarch64. More details on the errors and approaches can be found at https://github.com/dask-contrib/dask-sql/issues/1169

However, it seems practical to me to at least propose enabling the mimalloc `local_dynamic_tls` feature by default in ADP so that downstream libraries do you encounter this sort of behavior. I am open to other suggestions or configuration options as well but just wanted to get something started.