### PR TITLE
feat: udaf: enable multiple column input

### DIFF
--- a/datafusion/__init__.py
+++ b/datafusion/__init__.py
@@ -213,6 +213,8 @@ def udaf(accum, input_type, return_type, state_type, volatility, name=None):
         )
     if name is None:
         name = accum.__qualname__.lower()
+    if isinstance(input_type, pa.lib.DataType):
+        input_type = [input_type]
     return AggregateUDF(
         name=name,
         accumulator=accum,

--- a/src/udaf.rs
+++ b/src/udaf.rs
@@ -148,14 +148,14 @@ impl PyAggregateUDF {
     fn new(
         name: &str,
         accumulator: PyObject,
-        input_type: PyArrowType<DataType>,
+        input_type: PyArrowType<Vec<DataType>>,
         return_type: PyArrowType<DataType>,
         state_type: PyArrowType<Vec<DataType>>,
         volatility: &str,
     ) -> PyResult<Self> {
         let function = create_udaf(
             name,
-            vec![input_type.0],
+            input_type.0,
             Arc::new(return_type.0),
             parse_volatility(volatility)?,
             to_rust_accumulator(accumulator),


### PR DESCRIPTION
# Which issue does this PR close?

This PR does not close an issue but propagates the work of https://github.com/apache/arrow-datafusion/pull/7096 to `arrow-datafusion-python`

 # Rationale for this change

The functionality already exists in the underlying rust but is not exposed to the python interface.

# What changes are included in this PR?

`udaf` still accepts a single `pa.lib.DataType` as an input, but also accepts an iterable of `pa.lib.DataType`

# Are there any user-facing changes?

All previously working code will still work the same.