### PR TITLE
Add missing array functions

### DIFF
--- a/datafusion/tests/test_functions.py
+++ b/datafusion/tests/test_functions.py
@@ -245,6 +245,14 @@ def test_array_functions():
             f.list_extract(col, literal(1)),
             lambda: [r[0] for r in data],
         ],
+        [
+            f.array_length(col),
+            lambda: [len(r) for r in data],
+        ],
+        [
+            f.list_length(col),
+            lambda: [len(r) for r in data],
+        ],
     ]
 
     for stmt, py_expr in test_items:

--- a/datafusion/tests/test_functions.py
+++ b/datafusion/tests/test_functions.py
@@ -229,6 +229,22 @@ def test_array_functions():
             f.list_dims(col),
             lambda: [[len(r)] for r in data],
         ],
+        [
+            f.array_element(col, literal(1)),
+            lambda: [r[0] for r in data],
+        ],
+        [
+            f.array_extract(col, literal(1)),
+            lambda: [r[0] for r in data],
+        ],
+        [
+            f.list_element(col, literal(1)),
+            lambda: [r[0] for r in data],
+        ],
+        [
+            f.list_extract(col, literal(1)),
+            lambda: [r[0] for r in data],
+        ],
     ]
 
     for stmt, py_expr in test_items:

--- a/datafusion/tests/test_functions.py
+++ b/datafusion/tests/test_functions.py
@@ -25,6 +25,8 @@ from datafusion import SessionContext, column
 from datafusion import functions as f
 from datafusion import literal
 
+np.seterr(invalid="ignore")
+
 
 @pytest.fixture
 def df():
@@ -195,6 +197,36 @@ def test_math_functions():
     np.testing.assert_array_almost_equal(
         result.column(37), np.emath.logn(3, values + 1.0)
     )
+
+
+def test_array_functions():
+    data = [[1.0, 2.0, 3.0], [4.0, 5.0], [6.0]]
+    ctx = SessionContext()
+    batch = pa.RecordBatch.from_arrays(
+        [np.array(data, dtype=object)], names=["arr"]
+    )
+    df = ctx.create_dataframe([[batch]])
+
+    col = column("arr")
+    test_items = [
+        [
+            f.array_append(col, literal(99.0)),
+            lambda: [np.append(arr, 99.0) for arr in data],
+        ],
+        [
+            f.array_concat(col, col),
+            lambda: [np.concatenate([arr, arr]) for arr in data],
+        ],
+        [
+            f.array_cat(col, col),
+            lambda: [np.concatenate([arr, arr]) for arr in data],
+        ],
+    ]
+
+    for stmt, py_expr in test_items:
+        query_result = df.select(stmt).collect()[0].column(0).tolist()
+        for a, b in zip(query_result, py_expr()):
+            np.testing.assert_array_almost_equal(a, b)
 
 
 def test_string_functions(df):

--- a/datafusion/tests/test_functions.py
+++ b/datafusion/tests/test_functions.py
@@ -221,6 +221,14 @@ def test_array_functions():
             f.array_cat(col, col),
             lambda: [np.concatenate([arr, arr]) for arr in data],
         ],
+        [
+            f.array_dims(col),
+            lambda: [[len(r)] for r in data],
+        ],
+        [
+            f.list_dims(col),
+            lambda: [[len(r)] for r in data],
+        ],
     ]
 
     for stmt, py_expr in test_items:

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -356,6 +356,10 @@ scalar_function!(array_concat, ArrayConcat);
 scalar_function!(array_cat, ArrayConcat);
 scalar_function!(array_dims, ArrayDims);
 scalar_function!(list_dims, ArrayDims);
+scalar_function!(array_element, ArrayElement);
+scalar_function!(array_extract, ArrayElement);
+scalar_function!(list_element, ArrayElement);
+scalar_function!(list_extract, ArrayElement);
 
 aggregate_function!(approx_distinct, ApproxDistinct);
 aggregate_function!(approx_median, ApproxMedian);
@@ -553,6 +557,10 @@ pub(crate) fn init_module(m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(array_cat))?;
     m.add_wrapped(wrap_pyfunction!(array_dims))?;
     m.add_wrapped(wrap_pyfunction!(list_dims))?;
+    m.add_wrapped(wrap_pyfunction!(array_element))?;
+    m.add_wrapped(wrap_pyfunction!(array_extract))?;
+    m.add_wrapped(wrap_pyfunction!(list_element))?;
+    m.add_wrapped(wrap_pyfunction!(list_extract))?;
 
     Ok(())
 }

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -354,6 +354,8 @@ scalar_function!(decode, Decode);
 scalar_function!(array_append, ArrayAppend);
 scalar_function!(array_concat, ArrayConcat);
 scalar_function!(array_cat, ArrayConcat);
+scalar_function!(array_dims, ArrayDims);
+scalar_function!(list_dims, ArrayDims);
 
 aggregate_function!(approx_distinct, ApproxDistinct);
 aggregate_function!(approx_median, ApproxMedian);
@@ -549,6 +551,8 @@ pub(crate) fn init_module(m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(array_append))?;
     m.add_wrapped(wrap_pyfunction!(array_concat))?;
     m.add_wrapped(wrap_pyfunction!(array_cat))?;
+    m.add_wrapped(wrap_pyfunction!(array_dims))?;
+    m.add_wrapped(wrap_pyfunction!(list_dims))?;
 
     Ok(())
 }

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -360,6 +360,8 @@ scalar_function!(array_element, ArrayElement);
 scalar_function!(array_extract, ArrayElement);
 scalar_function!(list_element, ArrayElement);
 scalar_function!(list_extract, ArrayElement);
+scalar_function!(array_length, ArrayLength);
+scalar_function!(list_length, ArrayLength);
 
 aggregate_function!(approx_distinct, ApproxDistinct);
 aggregate_function!(approx_median, ApproxMedian);
@@ -561,6 +563,8 @@ pub(crate) fn init_module(m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(array_extract))?;
     m.add_wrapped(wrap_pyfunction!(list_element))?;
     m.add_wrapped(wrap_pyfunction!(list_extract))?;
+    m.add_wrapped(wrap_pyfunction!(array_length))?;
+    m.add_wrapped(wrap_pyfunction!(list_length))?;
 
     Ok(())
 }

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -350,6 +350,11 @@ scalar_function!(random, Random);
 scalar_function!(encode, Encode);
 scalar_function!(decode, Decode);
 
+// Array Functions
+scalar_function!(array_append, ArrayAppend);
+scalar_function!(array_concat, ArrayConcat);
+scalar_function!(array_cat, ArrayConcat);
+
 aggregate_function!(approx_distinct, ApproxDistinct);
 aggregate_function!(approx_median, ApproxMedian);
 aggregate_function!(approx_percentile_cont, ApproxPercentileCont);
@@ -539,5 +544,11 @@ pub(crate) fn init_module(m: &PyModule) -> PyResult<()> {
     //Binary String Functions
     m.add_wrapped(wrap_pyfunction!(encode))?;
     m.add_wrapped(wrap_pyfunction!(decode))?;
+
+    // Array Functions
+    m.add_wrapped(wrap_pyfunction!(array_append))?;
+    m.add_wrapped(wrap_pyfunction!(array_concat))?;
+    m.add_wrapped(wrap_pyfunction!(array_cat))?;
+
     Ok(())
 }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of  #463 

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Array functions should be implemented for the Python API.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Array functions:
- array_append
- array_concat
- array_cat
- array_dims
- list_dims
- array_element
- array_extract
- list_element
- list_extract
- array_length
- list_length

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

Yes.