### PR TITLE
Allow PyDataFrame to be used from other projects

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -842,7 +842,7 @@ impl PySessionContext {
     }
 }
 
-fn convert_table_partition_cols(
+pub fn convert_table_partition_cols(
     table_partition_cols: Vec<(String, String)>,
 ) -> Result<Vec<(String, DataType)>, DataFusionError> {
     table_partition_cols
@@ -856,7 +856,7 @@ fn convert_table_partition_cols(
         .collect::<Result<Vec<_>, _>>()
 }
 
-fn parse_file_compression_type(
+pub fn parse_file_compression_type(
     file_compression_type: Option<String>,
 ) -> Result<FileCompressionType, PyErr> {
     FileCompressionType::from_str(&*file_compression_type.unwrap_or("".to_string()).as_str())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@ mod config;
 #[allow(clippy::borrow_deref_ref)]
 pub mod context;
 #[allow(clippy::borrow_deref_ref)]
-mod dataframe;
+pub mod dataframe;
 mod dataset;
 mod dataset_exec;
 pub mod errors;
@@ -65,14 +65,14 @@ static GLOBAL: MiMalloc = MiMalloc;
 
 // Used to define Tokio Runtime as a Python module attribute
 #[pyclass]
-pub(crate) struct TokioRuntime(tokio::runtime::Runtime);
+pub struct TokioRuntime(pub tokio::runtime::Runtime);
 
 /// Low-level DataFusion internal package.
 ///
 /// The higher-level public API is defined in pure python files under the
 /// datafusion directory.
 #[pymodule]
-fn _internal(py: Python, m: &PyModule) -> PyResult<()> {
+pub fn _internal(py: Python, m: &PyModule) -> PyResult<()> {
     // Register the Tokio Runtime as a module attribute so we can reuse it
     m.add(
         "runtime",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,14 +65,14 @@ static GLOBAL: MiMalloc = MiMalloc;
 
 // Used to define Tokio Runtime as a Python module attribute
 #[pyclass]
-pub struct TokioRuntime(pub tokio::runtime::Runtime);
+pub(crate) struct TokioRuntime(tokio::runtime::Runtime);
 
 /// Low-level DataFusion internal package.
 ///
 /// The higher-level public API is defined in pure python files under the
 /// datafusion directory.
 #[pymodule]
-pub fn _internal(py: Python, m: &PyModule) -> PyResult<()> {
+fn _internal(py: Python, m: &PyModule) -> PyResult<()> {
     // Register the Tokio Runtime as a module attribute so we can reuse it
     m.add(
         "runtime",

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -23,7 +23,7 @@ use std::future::Future;
 use tokio::runtime::Runtime;
 
 /// Utility to get the Tokio Runtime from Python
-pub(crate) fn get_tokio_runtime(py: Python) -> PyRef<TokioRuntime> {
+pub fn get_tokio_runtime(py: Python) -> PyRef<TokioRuntime> {
     let datafusion = py.import("datafusion._internal").unwrap();
     let tmp = datafusion.getattr("runtime").unwrap();
     match tmp.extract::<PyRef<TokioRuntime>>() {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -23,7 +23,7 @@ use std::future::Future;
 use tokio::runtime::Runtime;
 
 /// Utility to get the Tokio Runtime from Python
-pub fn get_tokio_runtime(py: Python) -> PyRef<TokioRuntime> {
+pub(crate) fn get_tokio_runtime(py: Python) -> PyRef<TokioRuntime> {
     let datafusion = py.import("datafusion._internal").unwrap();
     let tmp = datafusion.getattr("runtime").unwrap();
     match tmp.extract::<PyRef<TokioRuntime>>() {


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/arrow-datafusion-python/issues/581

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

I would like other projects (such as PyBallista) to be able to re-use the `PyDataFrame` struct.

See https://github.com/apache/arrow-ballista/pull/976 for an example of how this is leveraged.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Make some things public.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->