### PR TITLE
Improved window and aggregate function signature

### DIFF
--- a/python/datafusion/expr.py
+++ b/python/datafusion/expr.py
@@ -216,9 +216,11 @@ __all__ = [
 
 
 def expr_list_to_raw_expr_list(
-    expr_list: Optional[list[Expr]],
+    expr_list: Optional[list[Expr] | Expr],
 ) -> Optional[list[expr_internal.Expr]]:
     """Helper function to convert an optional list to raw expressions."""
+    if isinstance(expr_list, Expr):
+        expr_list = [expr_list]
     return [e.expr for e in expr_list] if expr_list is not None else None
 
 
@@ -230,9 +232,11 @@ def sort_or_default(e: Expr | SortExpr) -> expr_internal.SortExpr:
 
 
 def sort_list_to_raw_sort_list(
-    sort_list: Optional[list[Expr | SortExpr]],
+    sort_list: Optional[list[Expr | SortExpr] | Expr | SortExpr],
 ) -> Optional[list[expr_internal.SortExpr]]:
     """Helper function to return an optional sort list to raw variant."""
+    if isinstance(sort_list, (Expr, SortExpr)):
+        sort_list = [sort_list]
     return [sort_or_default(e) for e in sort_list] if sort_list is not None else None
 
 
@@ -1140,9 +1144,9 @@ class Window:
 
     def __init__(
         self,
-        partition_by: Optional[list[Expr]] = None,
+        partition_by: Optional[list[Expr] | Expr] = None,
         window_frame: Optional[WindowFrame] = None,
-        order_by: Optional[list[SortExpr | Expr]] = None,
+        order_by: Optional[list[SortExpr | Expr] | Expr | SortExpr] = None,
         null_treatment: Optional[NullTreatment] = None,
     ) -> None:
         """Construct a window definition.

--- a/python/tests/test_aggregation.py
+++ b/python/tests/test_aggregation.py
@@ -154,6 +154,11 @@ def test_aggregation_stats(df, agg_expr, calc_expected):
             pa.array([[6, 4, 4]]),
             False,
         ),
+        (
+            f.array_agg(column("b"), order_by=column("c")),
+            pa.array([[6, 4, 4]]),
+            False,
+        ),
         (f.avg(column("b"), filter=column("a") != lit(1)), pa.array([5.0]), False),
         (f.sum(column("b"), filter=column("a") != lit(1)), pa.array([10]), False),
         (f.count(column("b"), distinct=True), pa.array([2]), False),
@@ -330,6 +335,15 @@ def test_bit_and_bool_fns(df, name, expr, result):
             [None, None],
         ),
         (
+            "first_value_no_list_order_by",
+            f.first_value(
+                column("b"),
+                order_by=column("b"),
+                null_treatment=NullTreatment.RESPECT_NULLS,
+            ),
+            [None, None],
+        ),
+        (
             "first_value_ignore_null",
             f.first_value(
                 column("b"),
@@ -342,6 +356,11 @@ def test_bit_and_bool_fns(df, name, expr, result):
             "last_value_ordered",
             f.last_value(column("a"), order_by=[column("a").sort(ascending=False)]),
             [0, 4],
+        ),
+        (
+            "last_value_no_list_ordered",
+            f.last_value(column("a"), order_by=column("a")),
+            [3, 6],
         ),
         (
             "last_value_with_null",
@@ -364,6 +383,11 @@ def test_bit_and_bool_fns(df, name, expr, result):
         (
             "nth_value_ordered",
             f.nth_value(column("a"), 2, order_by=[column("a").sort(ascending=False)]),
+            [2, 5],
+        ),
+        (
+            "nth_value_no_list_ordered",
+            f.nth_value(column("a"), 2, order_by=column("a").sort(ascending=False)),
             [2, 5],
         ),
         (
@@ -412,6 +436,11 @@ def test_first_last_value(df_partitioned, name, expr, result) -> None:
         (
             "string_agg",
             f.string_agg(column("a"), ",", order_by=[column("b")]),
+            "one,three,two,two",
+        ),
+        (
+            "string_agg",
+            f.string_agg(column("a"), ",", order_by=column("b")),
             "one,three,two,two",
         ),
     ],

--- a/python/tests/test_dataframe.py
+++ b/python/tests/test_dataframe.py
@@ -551,11 +551,24 @@ data_test_window_functions = [
         ),
         [2, 1, 3, 4, 2, 1, 3],
     ),
+    (
+        "row_w_params_no_lists",
+        f.row_number(
+            order_by=column("b"),
+            partition_by=column("c"),
+        ),
+        [2, 1, 3, 4, 2, 1, 3],
+    ),
     ("rank", f.rank(order_by=[column("b")]), [3, 1, 3, 5, 6, 1, 6]),
     (
         "rank_w_params",
         f.rank(order_by=[column("b"), column("a")], partition_by=[column("c")]),
         [2, 1, 3, 4, 2, 1, 3],
+    ),
+    (
+        "rank_w_params_no_lists",
+        f.rank(order_by=column("a"), partition_by=column("c")),
+        [1, 2, 3, 4, 1, 2, 3],
     ),
     (
         "dense_rank",
@@ -566,6 +579,11 @@ data_test_window_functions = [
         "dense_rank_w_params",
         f.dense_rank(order_by=[column("b"), column("a")], partition_by=[column("c")]),
         [2, 1, 3, 4, 2, 1, 3],
+    ),
+    (
+        "dense_rank_w_params_no_lists",
+        f.dense_rank(order_by=column("a"), partition_by=column("c")),
+        [1, 2, 3, 4, 1, 2, 3],
     ),
     (
         "percent_rank",
@@ -583,6 +601,14 @@ data_test_window_functions = [
         [0.333, 0.0, 0.667, 1.0, 0.5, 0.0, 1.0],
     ),
     (
+        "percent_rank_w_params_no_lists",
+        f.round(
+            f.percent_rank(order_by=column("a"), partition_by=column("c")),
+            literal(3),
+        ),
+        [0.0, 0.333, 0.667, 1.0, 0.0, 0.5, 1.0],
+    ),
+    (
         "cume_dist",
         f.round(f.cume_dist(order_by=[column("b")]), literal(3)),
         [0.571, 0.286, 0.571, 0.714, 1.0, 0.286, 1.0],
@@ -598,6 +624,14 @@ data_test_window_functions = [
         [0.5, 0.25, 0.75, 1.0, 0.667, 0.333, 1.0],
     ),
     (
+        "cume_dist_w_params_no_lists",
+        f.round(
+            f.cume_dist(order_by=column("a"), partition_by=column("c")),
+            literal(3),
+        ),
+        [0.25, 0.5, 0.75, 1.0, 0.333, 0.667, 1.0],
+    ),
+    (
         "ntile",
         f.ntile(2, order_by=[column("b")]),
         [1, 1, 1, 2, 2, 1, 2],
@@ -605,6 +639,11 @@ data_test_window_functions = [
     (
         "ntile_w_params",
         f.ntile(2, order_by=[column("b"), column("a")], partition_by=[column("c")]),
+        [1, 1, 2, 2, 1, 1, 2],
+    ),
+    (
+        "ntile_w_params_no_lists",
+        f.ntile(2, order_by=column("b"), partition_by=column("c")),
         [1, 1, 2, 2, 1, 1, 2],
     ),
     ("lead", f.lead(column("b"), order_by=[column("b")]), [7, None, 8, 9, 9, 7, None]),
@@ -616,6 +655,17 @@ data_test_window_functions = [
             default_value=-1,
             order_by=[column("b"), column("a")],
             partition_by=[column("c")],
+        ),
+        [8, 7, -1, -1, -1, 9, -1],
+    ),
+    (
+        "lead_w_params_no_lists",
+        f.lead(
+            column("b"),
+            shift_offset=2,
+            default_value=-1,
+            order_by=column("b"),
+            partition_by=column("c"),
         ),
         [8, 7, -1, -1, -1, 9, -1],
     ),
@@ -632,9 +682,27 @@ data_test_window_functions = [
         [-1, -1, None, 7, -1, -1, None],
     ),
     (
+        "lag_w_params_no_lists",
+        f.lag(
+            column("b"),
+            shift_offset=2,
+            default_value=-1,
+            order_by=column("b"),
+            partition_by=column("c"),
+        ),
+        [-1, -1, None, 7, -1, -1, None],
+    ),
+    (
         "first_value",
         f.first_value(column("a")).over(
             Window(partition_by=[column("c")], order_by=[column("b")])
+        ),
+        [1, 1, 1, 1, 5, 5, 5],
+    ),
+    (
+        "first_value_without_list_args",
+        f.first_value(column("a")).over(
+            Window(partition_by=column("c"), order_by=column("b"))
         ),
         [1, 1, 1, 1, 5, 5, 5],
     ),


### PR DESCRIPTION
# Which issue does this PR close?

None

 # Rationale for this change

This is a relatively minor change that allows users to pass a single expression for `order_by` and `partition_by` fields.

Without this change, if used improperly planning gets stuck in a loop. This improves ergonomics.

Old version required:

```python
df.select(f.lag(column("a"), order_by=[column("b")])
```

and now you can also write

```python
df.select(f.lag(column("a"), order_by=column("b"))
```

# What changes are included in this PR?

Enhances the check to see if we pass a single expression. When this is true, wrap it in a list. Added unit tests.

# Are there any user-facing changes?

This is a non-breaking signature change. It is backwards compatible.