### PR TITLE
feat: add temporary view option for into_view

### DIFF
--- a/python/datafusion/dataframe.py
+++ b/python/datafusion/dataframe.py
@@ -315,7 +315,7 @@ class DataFrame:
         """
         self.df = df
 
-    def into_view(self) -> Table:
+    def into_view(self, temporary: bool = False) -> Table:
         """Convert ``DataFrame`` into a :class:`~datafusion.Table`.
 
         Examples:
@@ -329,7 +329,7 @@ class DataFrame:
         """
         from datafusion.catalog import Table as _Table
 
-        return _Table(self.df.into_view())
+        return _Table(self.df.into_view(temporary))
 
     def __getitem__(self, key: str | list[str]) -> DataFrame:
         """Return a new :py:class`DataFrame` with the specified column or columns.

--- a/python/tests/test_context.py
+++ b/python/tests/test_context.py
@@ -357,10 +357,16 @@ def test_register_table_from_dataframe(ctx):
     assert [b.to_pydict() for b in result] == [{"a": [1, 2]}]
 
 
-def test_register_table_from_dataframe_into_view(ctx):
+@pytest.mark.parametrize("temporary", [True, False])
+def test_register_table_from_dataframe_into_view(ctx, temporary):
     df = ctx.from_pydict({"a": [1, 2]})
-    table = df.into_view()
+    table = df.into_view(temporary=temporary)
     assert isinstance(table, Table)
+    if temporary:
+        assert table.kind == "temporary"
+    else:
+        assert table.kind == "view"
+
     ctx.register_table("view_tbl", table)
     result = ctx.sql("SELECT * FROM view_tbl").collect()
     assert [b.to_pydict() for b in result] == [{"a": [1, 2]}]

--- a/src/dataframe.rs
+++ b/src/dataframe.rs
@@ -28,6 +28,7 @@ use arrow::pyarrow::FromPyArrow;
 use datafusion::arrow::datatypes::Schema;
 use datafusion::arrow::pyarrow::{PyArrowType, ToPyArrow};
 use datafusion::arrow::util::pretty;
+use datafusion::catalog::TableProvider;
 use datafusion::common::UnnestOptions;
 use datafusion::config::{CsvOptions, ParquetColumnOptions, ParquetOptions, TableParquetOptions};
 use datafusion::dataframe::{DataFrame, DataFrameWriteOptions};
@@ -47,7 +48,7 @@ use crate::expr::sort_expr::to_sort_expressions;
 use crate::physical_plan::PyExecutionPlan;
 use crate::record_batch::PyRecordBatchStream;
 use crate::sql::logical::PyLogicalPlan;
-use crate::table::PyTable;
+use crate::table::{PyTable, TempViewTable};
 use crate::utils::{
     get_tokio_runtime, is_ipython_env, py_obj_to_scalar_value, validate_pycapsule, wait_for_future,
 };
@@ -418,11 +419,15 @@ impl PyDataFrame {
     /// because we're working with Python bindings
     /// where objects are shared
     #[allow(clippy::wrong_self_convention)]
-    pub fn into_view(&self) -> PyDataFusionResult<PyTable> {
-        // Call the underlying Rust DataFrame::into_view method.
-        // Note that the Rust method consumes self; here we clone the inner Arc<DataFrame>
-        // so that we don't invalidate this PyDataFrame.
-        let table_provider = self.df.as_ref().clone().into_view();
+    pub fn into_view(&self, temporary: bool) -> PyDataFusionResult<PyTable> {
+        let table_provider = if temporary {
+            Arc::new(TempViewTable::new(Arc::clone(&self.df))) as Arc<dyn TableProvider>
+        } else {
+            // Call the underlying Rust DataFrame::into_view method.
+            // Note that the Rust method consumes self; here we clone the inner Arc<DataFrame>
+            // so that we don't invalidate this PyDataFrame.
+            self.df.as_ref().clone().into_view()
+        };
         Ok(PyTable::from(table_provider))
     }
 


### PR DESCRIPTION
# Which issue does this PR close?

None

 # Rationale for this change

This feature allows for creating *temporary* views. It is needed for the follow on work in #513 

# What changes are included in this PR?

- Adds one parameter to `.into_view()` on the DataFrame to set if the view should be temporary
- Adds `TempViewTable` to create a temporary view. This is a copy of `DataFrameTableProvider` from the upstream repo until https://github.com/apache/datafusion/issues/18026 is resolved
- Updates unit test to check both temporary and permanent views

# Are there any user-facing changes?

No. Existing code will continue to work as is. This only added an optional parameter to the user facing API.