### PR TITLE
feat: support session token parameter for AmazonS3

### DIFF
--- a/src/store.rs
+++ b/src/store.rs
@@ -179,13 +179,14 @@ pub struct PyAmazonS3Context {
 #[pymethods]
 impl PyAmazonS3Context {
     #[allow(clippy::too_many_arguments)]
-    #[pyo3(signature = (bucket_name, region=None, access_key_id=None, secret_access_key=None, endpoint=None, allow_http=false, imdsv1_fallback=false))]
+    #[pyo3(signature = (bucket_name, region=None, access_key_id=None, secret_access_key=None, session_token=None, endpoint=None, allow_http=false, imdsv1_fallback=false))]
     #[new]
     fn new(
         bucket_name: String,
         region: Option<String>,
         access_key_id: Option<String>,
         secret_access_key: Option<String>,
+        session_token: Option<String>,
         endpoint: Option<String>,
         //retry_config: RetryConfig,
         allow_http: bool,
@@ -205,6 +206,10 @@ impl PyAmazonS3Context {
         if let Some(secret_access_key) = secret_access_key {
             builder = builder.with_secret_access_key(secret_access_key);
         };
+
+        if let Some(session_token) = session_token {
+            builder = builder.with_token(session_token);
+        }
 
         if let Some(endpoint) = endpoint {
             builder = builder.with_endpoint(endpoint);


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1133 

# Rationale for this change

This is a small change to allow passing a session token through to the object store. There is discussion in the issue (and elsewhere) on switching to a different library, doing so would superseded this change. This change will make using temporary credentials much neater/easier until that change is made however.

# What changes are included in this PR?

Add optional parameter to AmazonS3 to pass a session_token through to the builder

# Are there any user-facing changes?

new optional parameter to the `AmazonS3` object store `session_token` that passes through to the `AmazonS3Builder`