### PR TITLE
feat: allow DataFrame.filter to accept SQL strings

### DIFF
--- a/docs/source/user-guide/dataframe/index.rst
+++ b/docs/source/user-guide/dataframe/index.rst
@@ -95,8 +95,9 @@ DataFusion's DataFrame API offers a wide range of operations:
     # Select with expressions
     df = df.select(column("a") + column("b"), column("a") - column("b"))
     
-    # Filter rows
+    # Filter rows (expressions or SQL strings)
     df = df.filter(column("age") > literal(25))
+    df = df.filter("age > 25")
     
     # Add computed columns
     df = df.with_column("full_name", column("first_name") + literal(" ") + column("last_name"))


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1273

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
Users have requested Spark-like support for `DataFrame.filter("a > 1")` so they can reuse existing SQL predicate strings without converting them to expression objects.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
- Allow `DataFrame.filter` to normalize SQL string predicates via `parse_sql_expr` before dispatching to the internal API.
- Add regression tests covering pure SQL strings, mixed string/Expr predicates, and invalid SQL errors.
- Update the DataFrame user guide to mention SQL string filtering.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
`DataFrame.filter` now accepts SQL string predicates in addition to `Expr` objects, and the documentation reflects this capability. No breaking API changes.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->