### PR TITLE
Add collect_column to dataframe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1596,6 +1596,7 @@ name = "datafusion-python"
 version = "50.1.0"
 dependencies = [
  "arrow",
+ "arrow-select",
  "async-trait",
  "cstr",
  "datafusion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ pyo3 = { version = "0.25", features = [
 pyo3-async-runtimes = { version = "0.25", features = ["tokio-runtime"] }
 pyo3-log = "0.12.4"
 arrow = { version = "56", features = ["pyarrow"] }
+arrow-select = { version = "56" }
 datafusion = { version = "50", features = ["avro", "unicode_expressions"] }
 datafusion-substrait = { version = "50", optional = true }
 datafusion-proto = { version = "50" }

--- a/docs/source/user-guide/dataframe/index.rst
+++ b/docs/source/user-guide/dataframe/index.rst
@@ -200,6 +200,9 @@ To materialize the results of your DataFrame operations:
     # Count rows
     count = df.count()
 
+    # Collect a single column of data as a PyArrow Array
+    arr = df.collect_column("age")
+
 Zero-copy streaming to Arrow-based Python libraries
 ---------------------------------------------------
 
@@ -238,7 +241,7 @@ PyArrow:
 
 Each batch exposes ``to_pyarrow()``, allowing conversion to a PyArrow
 table. ``pa.table(df)`` collects the entire DataFrame eagerly into a
-PyArrow table::
+PyArrow table:
 
 .. code-block:: python
 
@@ -246,7 +249,7 @@ PyArrow table::
     table = pa.table(df)
 
 Asynchronous iteration is supported as well, allowing integration with
-``asyncio`` event loops::
+``asyncio`` event loops:
 
 .. code-block:: python
 

--- a/python/datafusion/dataframe.py
+++ b/python/datafusion/dataframe.py
@@ -728,6 +728,10 @@ class DataFrame:
         """
         return self.df.collect()
 
+    def collect_column(self, column_name: str) -> pa.Array | pa.ChunkedArray:
+        """Executes this :py:class:`DataFrame` for a single column."""
+        return self.df.collect_column(column_name)
+
     def cache(self) -> DataFrame:
         """Cache the DataFrame as a memory table.
 

--- a/python/tests/test_dataframe.py
+++ b/python/tests/test_dataframe.py
@@ -1733,6 +1733,18 @@ def test_collect_partitioned():
     assert [[batch]] == ctx.create_dataframe([[batch]]).collect_partitioned()
 
 
+def test_collect_column(ctx: SessionContext):
+    batch_1 = pa.RecordBatch.from_pydict({"a": [1, 2, 3]})
+    batch_2 = pa.RecordBatch.from_pydict({"a": [4, 5, 6]})
+    batch_3 = pa.RecordBatch.from_pydict({"a": [7, 8, 9]})
+
+    ctx.register_record_batches("t", [[batch_1, batch_2], [batch_3]])
+
+    result = ctx.table("t").sort(column("a")).collect_column("a")
+    expected = pa.array([1, 2, 3, 4, 5, 6, 7, 8, 9])
+    assert result == expected
+
+
 def test_union(ctx):
     batch = pa.RecordBatch.from_arrays(
         [pa.array([1, 2, 3]), pa.array([4, 5, 6])],


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1288

 # Rationale for this change

This PR adds a function to extract a single column of data from a dataframe and return it as a pyarrow array. It is based on user feedback that they must go through complicated lengths to get access to this data.

# What changes are included in this PR?

- Adds `collect_column` function to DataFrame
- Adds unit test

# Are there any user-facing changes?

This is a new API. No existing APIs have been modified.