### PR TITLE
Add use_fabric_endpoint parameter to MicrosoftAzure class

### DIFF
--- a/src/store.rs
+++ b/src/store.rs
@@ -76,7 +76,7 @@ pub struct PyMicrosoftAzureContext {
 #[pymethods]
 impl PyMicrosoftAzureContext {
     #[allow(clippy::too_many_arguments)]
-    #[pyo3(signature = (container_name, account=None, access_key=None, bearer_token=None, client_id=None, client_secret=None, tenant_id=None, sas_query_pairs=None, use_emulator=None, allow_http=None))]
+    #[pyo3(signature = (container_name, account=None, access_key=None, bearer_token=None, client_id=None, client_secret=None, tenant_id=None, sas_query_pairs=None, use_emulator=None, allow_http=None, use_fabric_endpoint=None))]
     #[new]
     fn new(
         container_name: String,
@@ -89,6 +89,7 @@ impl PyMicrosoftAzureContext {
         sas_query_pairs: Option<Vec<(String, String)>>,
         use_emulator: Option<bool>,
         allow_http: Option<bool>,
+        use_fabric_endpoint: Option<bool>,
     ) -> Self {
         let mut builder = MicrosoftAzureBuilder::from_env().with_container_name(&container_name);
 
@@ -125,6 +126,10 @@ impl PyMicrosoftAzureContext {
 
         if let Some(allow_http) = allow_http {
             builder = builder.with_allow_http(allow_http);
+        }
+
+        if let Some(use_fabric_endpoint) = use_fabric_endpoint {
+            builder = builder.with_use_fabric_endpoint(use_fabric_endpoint);
         }
 
         Self {


### PR DESCRIPTION
## Summary

This PR adds support for the `use_fabric_endpoint` parameter to the `MicrosoftAzure` object store class, enabling connections to Microsoft Fabric OneLake storage.

Fixes #1356

## Problem

The Python `MicrosoftAzure` class was missing the `use_fabric_endpoint` parameter that exists in the underlying Rust `object_store` crate. This prevented users from connecting to Microsoft Fabric OneLake storage, which requires Data Lake Storage Gen2 endpoints instead of Azure Blob Storage endpoints.

**Current behavior**: Defaults to `https://onelake.blob.core.windows.net/...`  
**Required behavior**: Support `https://onelake.dfs.fabric.microsoft.com/...`

## Changes

Added the `use_fabric_endpoint` parameter to the `MicrosoftAzure` class in `src/store.rs`:

1. Added parameter to PyO3 signature macro (line 79)
2. Added parameter to function signature as `Option<bool>` (line 92)
3. Added conditional builder chain call to `with_use_fabric_endpoint()` (lines 130-132)

This implementation follows the exact same pattern as existing boolean parameters (`use_emulator`, `allow_http`).

## Usage Example

```python
from datafusion.object_store import MicrosoftAzure
from datafusion import SessionContext
import os

# Create OneLake store with Fabric endpoint
onelake_store = MicrosoftAzure(
    container_name="tpch",
    account='onelake',
    bearer_token=os.environ["AZURE_STORAGE_TOKEN"],
    use_fabric_endpoint=True  # NEW PARAMETER
)

# Register and use
ctx = SessionContext()
ctx.register_object_store("abfss://tpch@onelake.dfs.fabric.microsoft.com/storage.Lakehouse", onelake_store, None)
```

## Testing Note

Comprehensive end-to-end testing of this feature requires:
- An active Microsoft Fabric workspace
- OneLake storage with data
- Valid authentication tokens for OneLake access

I have manually verified that:
- The parameter is accepted without errors
- The object store can be successfully registered with a SessionContext
- Queries against OneLake storage work correctly with `use_fabric_endpoint=True`

The code change is minimal and follows existing patterns exactly, making it low-risk for existing functionality.

<img width="701" height="301" alt="image" src="https://github.com/user-attachments/assets/6b33060b-e4ca-4aa0-ba50-2309d3b8963d" />


## Checklist

- [x] Follows existing code patterns
- [x] Minimal, focused change
- [x] Manually tested with OneLake
- [x] No new dependencies required