### PR TITLE
minor: remove ffi test wheel from distribution artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -176,13 +176,17 @@ jobs:
           args: --out dist
           rustup-components: rust-std
 
-      - run: cp examples/datafusion-ffi-example/dist/*.whl dist/
-
       - name: Archive wheels
         uses: actions/upload-artifact@v6
         with:
           name: dist-manylinux-x86_64
           path: dist/*
+
+      - name: Archive FFI test wheel
+        uses: actions/upload-artifact@v6
+        with:
+          name: test-ffi-manylinux-x86_64
+          path: examples/datafusion-ffi-example/dist/*
 
   # ============================================
   # Build - Linux ARM64

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,6 +86,13 @@ jobs:
           name: dist-manylinux-x86_64
           path: wheels/
 
+      # Download the FFI test wheel
+      - name: Download pre-built FFI test wheel
+        uses: actions/download-artifact@v7
+        with:
+          name: test-ffi-manylinux-x86_64
+          path: wheels/
+
       # Install from the pre-built wheels
       - name: Install from pre-built wheels
         run: |


### PR DESCRIPTION
This is a follow up to https://github.com/apache/datafusion-python/pull/1375

We are currently including the FFI test wheel in our distribution artifact. This should not be included.