### PR TITLE
fix: satisfy rustfmt check in lib.rs re-exports

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,9 +16,9 @@
 // under the License.
 
 // Re-export Apache Arrow DataFusion dependencies
-pub use datafusion;
 pub use datafusion::{
-    common as datafusion_common, logical_expr as datafusion_expr, optimizer, sql as datafusion_sql,
+    self, common as datafusion_common, logical_expr as datafusion_expr, optimizer,
+    sql as datafusion_sql,
 };
 #[cfg(feature = "substrait")]
 pub use datafusion_substrait;


### PR DESCRIPTION
## Summary
- remove standalone pub use datafusion;
- include self in grouped pub use datafusion::{ ... } re-export
- format import list to match rustfmt output

## Validation
- cargo +nightly fmt --all -- --check


CI is currently broken due to this issue. I found this while looking at #1405