### PR TITLE
Add docstring examples for Aggregate basic and bitwise/boolean functions

### DIFF
--- a/python/datafusion/functions.py
+++ b/python/datafusion/functions.py
@@ -1901,7 +1901,7 @@ def approx_distinct(
     >>> df = ctx.from_pydict({"a": [1, 1, 2, 3]})
     >>> result = df.aggregate(
     ...     [], [dfn.functions.approx_distinct(dfn.col("a")).alias("v")])
-    >>> result.collect_column("v")[0].as_py() >= 2
+    >>> result.collect_column("v")[0].as_py() == 3
     True
     """
     filter_raw = filter.expr if filter is not None else None


### PR DESCRIPTION
# Which issue does this PR close?
* Part 3 of https://github.com/apache/datafusion-python/pull/1400
* Related to https://github.com/apache/datafusion-python/issues/1394

 # Rationale for this change
Add example usage to docstrings for Aggregate basic and bitwise/boolean functions to improve documentation.

# What changes are included in this PR?
The first PR was basically adding a docstring to everything in functions. I broke it apart into a PR (that already merged) for the infra. I then reviewed and merged an example PR of adding the docstrings in parts. This is now the follow up opening a handful of PRs for the remaining functions in functions.py Everything is co-authored with Claude since I used claude to extend the handwritten examples I wrote for reference and to split apart the large PR rather than doing it manually.

I've reviewed all the code prior to PR.

# Are there any user-facing changes?
No