### PR TITLE
TEST main erros

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,12 +89,18 @@ jobs:
             exit 1
           fi
 
-      - name: Run tests
+      - name: Run unit tests
         env:
           RUST_BACKTRACE: 1
         run: |
           git submodule update --init
-          uv run --no-project pytest -v --import-mode=importlib
+          uv run --no-project pytest -v --import-mode=importlib python/tests
+
+      - name: Run doctests
+        env:
+          RUST_BACKTRACE: 1
+        run: |
+          uv run --no-project pytest -v --import-mode=importlib --doctest-modules python/datafusion
 
       - name: FFI unit tests
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,6 @@ features = ["substrait"]
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
-addopts = "--doctest-modules"
 doctest_optionflags = ["NORMALIZE_WHITESPACE", "ELLIPSIS"]
 testpaths = ["python/tests", "python/datafusion"]
 


### PR DESCRIPTION
Eliminate global doctest enablement from pytest defaults by removing the addopts line in pyproject.toml.

Split the CI test execution in test.yml:92 to run unit tests. Run doctests in a separate step using --doctest-modules for the datafusion package at test.yml:99.

# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->