### PR TITLE
Complete doc string examples for functions.py

### DIFF
--- a/python/datafusion/functions.py
+++ b/python/datafusion/functions.py
@@ -4609,7 +4609,6 @@ def nth_value(
         >>> result.collect_column("v")[0].as_py()
         10
 
-        >>> df = ctx.from_pydict({"a": [10, 20, 30]})
         >>> result = df.aggregate(
         ...     [], [dfn.functions.nth_value(
         ...         dfn.col("a"), 1,


### PR DESCRIPTION
# Which issue does this PR close?
Closes #1434 and #1433

 # Rationale for this change
Added coverage over MOST functions in functions.py with examples but split things up to be reviewable. There were a couple global notes that got lost across the many PRs

~This relies on https://github.com/apache/datafusion-python/pull/1418 landing first since I branched from there.~ (MERGED and rebased)
This PR isn't as large as the diff suggests because a lot of changes are simple formatting. Reviewing by commit should make it much easier.
* Cover remaining functions
* Format aliases with See Also blocks
* Format Examples to match google doc string style (biggest churn)
* Remove unnecessary use of builtins
* Cover optional arguments (in multiple commits to chunk it up)