### PR TITLE
docs: clarify DataFusion 52 FFI session-parameter requirement for provider hooks

### DIFF
--- a/docs/source/user-guide/upgrade-guides.rst
+++ b/docs/source/user-guide/upgrade-guides.rst
@@ -52,6 +52,10 @@ parameter, which is a Python object that can be used to extract the
 ``FFI_LogicalExtensionCodec`` that is necessary.
 
 A complete example can be found in the `FFI example <https://github.com/apache/datafusion-python/tree/main/examples/datafusion-ffi-example>`_.
+Your FFI hook methods — ``__datafusion_catalog_provider__``,
+``__datafusion_schema_provider__``, ``__datafusion_table_provider__``, and
+``__datafusion_table_function__`` — need to be updated to accept an additional
+``session: Bound<PyAny>`` parameter, as shown in this example.
 
 .. code-block:: rust
 
@@ -95,38 +99,6 @@ can implement a helper method such as:
 
         Ok(codec.clone())
     }
-
-
-Your methods need to be updated to take an additional ``session`` parameter.
-For example, the ``__datafusion_catalog_provider__`` signature changed in
-DataFusion 52 from:
-
-.. code-block:: rust
-
-    pub fn __datafusion_catalog_provider__<'py>(
-        &self,
-        py: Python<'py>,
-    ) -> PyResult<Bound<'py, PyCapsule>>
-
-to:
-
-.. code-block:: rust
-
-    pub fn __datafusion_catalog_provider__<'py>(
-        &self,
-        py: Python<'py>,
-        session: Bound<PyAny>,
-    ) -> PyResult<Bound<'py, PyCapsule>>
-
-The same additional ``session: Bound<PyAny>`` parameter is required for these
-FFI hook methods in DataFusion 52:
-
-- ``__datafusion_table_provider__``
-- ``__datafusion_schema_provider__``
-- ``__datafusion_table_function__``
-
-If your hook still uses the old no-``session`` signature, update it to accept
-``session``.
 
 
 The DataFusion FFI interface updates no longer depend directly on the


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
This PR updates the DataFusion 52.0.0 upgrade guide to explicitly document the breaking signature change for FFI provider hooks that now require a `session` parameter.

The `session` parameter was added [in this PR](https://github.com/apache/datafusion-python/pull/1337/files#diff-ab4c8cde88a6ba7347571f7fc56080db0c4f5a59ac737e15bb8c87d3094fa8daR91)

Without the `session` parameter, datafusion integrations will error with

> Incompatible libraries. DataFusion 52.0.0 introduced an incompatible signature change for table functions. Either downgrade DataFusion or upgrade your function library.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->