### PR TITLE
ci: disable symbol export on Windows verification

### DIFF
--- a/.github/workflows/verify-release-candidate.yml
+++ b/.github/workflows/verify-release-candidate.yml
@@ -73,10 +73,10 @@ jobs:
           version: "27.4"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Switch to MSVC Rust toolchain (Windows)
+      - name: Set RUSTFLAGS for Windows GNU linker
         if: matrix.os == 'windows'
         shell: bash
-        run: rustup default stable-x86_64-pc-windows-msvc
+        run: echo "RUSTFLAGS=-C link-arg=-Wl,--exclude-libs=ALL" >> "$GITHUB_ENV"
 
       - name: Run release candidate verification
         shell: bash

--- a/.github/workflows/verify-release-candidate.yml
+++ b/.github/workflows/verify-release-candidate.yml
@@ -73,10 +73,10 @@ jobs:
           version: "27.4"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set RUSTFLAGS for Windows GNU linker
+      - name: Switch to MSVC Rust toolchain (Windows)
         if: matrix.os == 'windows'
         shell: bash
-        run: echo "RUSTFLAGS=-C link-arg=-Wl,--exclude-libs=ALL" >> "$GITHUB_ENV"
+        run: rustup default stable-x86_64-pc-windows-msvc
 
       - name: Run release candidate verification
         shell: bash

--- a/.github/workflows/verify-release-candidate.yml
+++ b/.github/workflows/verify-release-candidate.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Set RUSTFLAGS for Windows GNU linker
         if: matrix.os == 'windows'
         shell: bash
-        run: echo "RUSTFLAGS=-C link-arg=--exclude-libs=ALL" >> "$GITHUB_ENV"
+        run: echo "RUSTFLAGS=-C link-arg=-Wl,--exclude-libs=ALL" >> "$GITHUB_ENV"
 
       - name: Run release candidate verification
         shell: bash

--- a/.github/workflows/verify-release-candidate.yml
+++ b/.github/workflows/verify-release-candidate.yml
@@ -73,6 +73,11 @@ jobs:
           version: "27.4"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set RUSTFLAGS for Windows GNU linker
+        if: matrix.os == 'windows'
+        shell: bash
+        run: echo "RUSTFLAGS=-C link-arg=--exclude-libs=ALL" >> "$GITHUB_ENV"
+
       - name: Run release candidate verification
         shell: bash
         run: ./dev/release/verify-release-candidate.sh "${{ inputs.version }}" "${{ inputs.rc_number }}"


### PR DESCRIPTION
# Which issue does this PR close?

None, but the verification script was failing on windows.

 # Rationale for this change

Linker was failing on 53.0.0 even though our CI builds were fine. This appears to be due to the debug build and number of linked objects in 53.0.0. This sets a build variable to avoid this issue.

# What changes are included in this PR?

Sets linker flag in verification script.

# Are there any user-facing changes?

No

# Testing

Demonstration that it now works:

https://github.com/apache/datafusion-python/actions/runs/24263082673