### PR TITLE
Support None comparisons for null expressions

### DIFF
--- a/python/datafusion/expr.py
+++ b/python/datafusion/expr.py
@@ -483,6 +483,8 @@ class Expr:  # noqa: PLW1641
 
         Accepts either an expression or any valid PyArrow scalar literal value.
         """
+        if rhs is None:
+            return self.is_null()
         if not isinstance(rhs, Expr):
             rhs = Expr.literal(rhs)
         return Expr(self.expr.__eq__(rhs.expr))
@@ -492,6 +494,8 @@ class Expr:  # noqa: PLW1641
 
         Accepts either an expression or any valid PyArrow scalar literal value.
         """
+        if rhs is None:
+            return self.is_not_null()
         if not isinstance(rhs, Expr):
             rhs = Expr.literal(rhs)
         return Expr(self.expr.__ne__(rhs.expr))

--- a/python/tests/test_expr.py
+++ b/python/tests/test_expr.py
@@ -153,8 +153,8 @@ def test_relational_expr(test_ctx):
 
     batch = pa.RecordBatch.from_arrays(
         [
-            pa.array([1, 2, 3]),
-            pa.array(["alpha", "beta", "gamma"], type=pa.string_view()),
+            pa.array([1, 2, 3, None]),
+            pa.array(["alpha", "beta", "gamma", None], type=pa.string_view()),
         ],
         names=["a", "b"],
     )
@@ -171,24 +171,10 @@ def test_relational_expr(test_ctx):
     assert df.filter(col("b") != "beta").count() == 2
 
     assert df.filter(col("a") == "beta").count() == 0
-
-
-def test_relational_expr_none_uses_null_predicates():
-    ctx = SessionContext()
-
-    batch = pa.RecordBatch.from_arrays(
-        [
-            pa.array([1, 2, None]),
-            pa.array(["alpha", None, "gamma"], type=pa.string_view()),
-        ],
-        names=["a", "b"],
-    )
-    df = ctx.create_dataframe([[batch]], name="batch_with_nulls")
-
     assert df.filter(col("a") == None).count() == 1  # noqa: E711
-    assert df.filter(col("a") != None).count() == 2  # noqa: E711
+    assert df.filter(col("a") != None).count() == 3  # noqa: E711
     assert df.filter(col("b") == None).count() == 1  # noqa: E711
-    assert df.filter(col("b") != None).count() == 2  # noqa: E711
+    assert df.filter(col("b") != None).count() == 3  # noqa: E711
 
 
 def test_expr_to_variant():

--- a/python/tests/test_expr.py
+++ b/python/tests/test_expr.py
@@ -173,6 +173,24 @@ def test_relational_expr(test_ctx):
     assert df.filter(col("a") == "beta").count() == 0
 
 
+def test_relational_expr_none_uses_null_predicates():
+    ctx = SessionContext()
+
+    batch = pa.RecordBatch.from_arrays(
+        [
+            pa.array([1, 2, None]),
+            pa.array(["alpha", None, "gamma"], type=pa.string_view()),
+        ],
+        names=["a", "b"],
+    )
+    df = ctx.create_dataframe([[batch]], name="batch_with_nulls")
+
+    assert df.filter(col("a") == None).count() == 1  # noqa: E711
+    assert df.filter(col("a") != None).count() == 2  # noqa: E711
+    assert df.filter(col("b") == None).count() == 1  # noqa: E711
+    assert df.filter(col("b") != None).count() == 2  # noqa: E711
+
+
 def test_expr_to_variant():
     # Taken from https://github.com/apache/datafusion-python/issues/781
     from datafusion import SessionContext


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1483.

# Rationale for this change

Comparing expressions to `None` with `==` currently builds a regular equality comparison against a null literal, which follows SQL null semantics and does not match null values in filters. This is surprising for Python users, especially since comparing against other scalar values works as expected and the equivalent `.is_null()` expression does return the expected rows.

# What changes are included in this PR?

- Special-case `Expr.__eq__` so `expr == None` maps to `expr.is_null()`
- Special-case `Expr.__ne__` so `expr != None` maps to `expr.is_not_null()`
- Add regression tests covering `== None` and `!= None` on nullable integer and string columns

# Are there any user-facing changes?

Yes. Python users can now write `col("a") == None` and `col("a") != None` as shorthand for `is_null()` and `is_not_null()`.

`is None` is not supported because Python identity checks cannot be overloaded.
