### PR TITLE
Fix error on show() with an explain plan

### DIFF
--- a/crates/core/src/dataframe.rs
+++ b/crates/core/src/dataframe.rs
@@ -38,8 +38,8 @@ use datafusion::dataframe::{DataFrame, DataFrameWriteOptions};
 use datafusion::error::DataFusionError;
 use datafusion::execution::SendableRecordBatchStream;
 use datafusion::execution::context::TaskContext;
-use datafusion::logical_expr::SortExpr;
 use datafusion::logical_expr::dml::InsertOp;
+use datafusion::logical_expr::{LogicalPlan, SortExpr};
 use datafusion::parquet::basic::{BrotliLevel, Compression, GzipLevel, ZstdLevel};
 use datafusion::physical_plan::{
     ExecutionPlan as DFExecutionPlan, collect as df_collect,
@@ -707,7 +707,15 @@ impl PyDataFrame {
     /// Print the result, 20 lines by default
     #[pyo3(signature = (num=20))]
     fn show(&self, py: Python, num: usize) -> PyDataFusionResult<()> {
-        let df = self.df.as_ref().clone().limit(0, Some(num))?;
+        let mut df = self.df.as_ref().clone();
+        df = match self.df.logical_plan() {
+            LogicalPlan::Explain(_) | LogicalPlan::Analyze(_) => {
+                // Explain and Analyzer require they are at the top
+                // of the plan, so do not add a limit.
+                df
+            }
+            _ => df.limit(0, Some(num))?,
+        };
         print_dataframe(py, df)
     }
 

--- a/python/tests/test_dataframe.py
+++ b/python/tests/test_dataframe.py
@@ -412,6 +412,16 @@ def test_show_empty(df, capsys):
     assert "DataFrame has no rows" in captured.out
 
 
+def test_show_on_explain(ctx, capsys):
+    ctx.sql("explain select 1").show()
+    captured = capsys.readouterr()
+    assert "1 as Int64(1)" in captured.out
+
+    ctx.sql("explain analyze select 1").show()
+    captured = capsys.readouterr()
+    assert "1 as Int64(1)" in captured.out
+
+
 def test_sort(df):
     df = df.sort(column("b").sort(ascending=False))
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1490

 # Rationale for this change

`.show()` is adding a limit on the dataframe, but this is not allowed for explain and analyze plans.

# What changes are included in this PR?

If we have an explain or analyze plan, do not add limit during show.

# Are there any user-facing changes?

None