### PR TITLE
minor: fix header on agent SKILL.md file

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,22 +1,3 @@
-<!---
-  Licensed to the Apache Software Foundation (ASF) under one
-  or more contributor license agreements.  See the NOTICE file
-  distributed with this work for additional information
-  regarding copyright ownership.  The ASF licenses this file
-  to you under the Apache License, Version 2.0 (the
-  "License"); you may not use this file except in compliance
-  with the License.  You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing,
-  software distributed under the License is distributed on an
-  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  KIND, either express or implied.  See the License for the
-  specific language governing permissions and limitations
-  under the License.
--->
-
 ---
 name: datafusion-python
 description: Use when the user is writing datafusion-python (Apache DataFusion Python bindings) DataFrame or SQL code. Covers imports, data loading, DataFrame operations, expression building, SQL-to-DataFrame mappings, idiomatic patterns, and common pitfalls.

--- a/dev/release/rat_exclude_files.txt
+++ b/dev/release/rat_exclude_files.txt
@@ -49,3 +49,4 @@ benchmarks/tpch/create_tables.sql
 **/.cargo/config.toml
 uv.lock
 examples/tpch/answers_sf1/*.tbl
+SKILL.md


### PR DESCRIPTION
# Which issue does this PR close?

None

 # Rationale for this change

Skill discover requires the header be the first thing in the file.
RAT checks require the Apache license be the first thing in the file.

This makes an exception for this file so the skill can be discoverable.

# What changes are included in this PR?

Remove license text.
Add exception to RAT.

# Are there any user-facing changes?

None