### PR TITLE
docs: document null-handling function arguments

### DIFF
--- a/python/datafusion/functions.py
+++ b/python/datafusion/functions.py
@@ -908,6 +908,9 @@ def chr(arg: Expr) -> Expr:
 def coalesce(*args: Expr) -> Expr:
     """Returns the value of the first expr in ``args`` which is not NULL.
 
+    Args:
+        *args: Expressions to evaluate in order.
+
     Examples:
         >>> ctx = dfn.SessionContext()
         >>> df = ctx.from_pydict({"a": [None, 1], "b": [2, 3]})
@@ -1088,6 +1091,10 @@ def greatest(*args: Expr) -> Expr:
 
 def ifnull(x: Expr, y: Expr) -> Expr:
     """Returns ``x`` if ``x`` is not NULL. Otherwise returns ``y``.
+
+    Args:
+        x: Expression to return when it is not NULL.
+        y: Fallback expression to return when ``x`` is NULL.
 
     See Also:
         This is an alias for :py:func:`nvl`.
@@ -1323,6 +1330,10 @@ def md5(arg: Expr) -> Expr:
 def nanvl(x: Expr, y: Expr) -> Expr:
     """Returns ``x`` if ``x`` is not ``NaN``. Otherwise returns ``y``.
 
+    Args:
+        x: Expression to return when it is not NaN.
+        y: Fallback expression to return when ``x`` is NaN.
+
     Examples:
         >>> ctx = dfn.SessionContext()
         >>> df = ctx.from_pydict({"a": [np.nan, 1.0], "b": [0.0, 0.0]})
@@ -1338,6 +1349,10 @@ def nanvl(x: Expr, y: Expr) -> Expr:
 
 def nvl(x: Expr, y: Expr) -> Expr:
     """Returns ``x`` if ``x`` is not ``NULL``. Otherwise returns ``y``.
+
+    Args:
+        x: Expression to return when it is not NULL.
+        y: Fallback expression to return when ``x`` is NULL.
 
     Examples:
         >>> ctx = dfn.SessionContext()
@@ -1355,6 +1370,11 @@ def nvl(x: Expr, y: Expr) -> Expr:
 
 def nvl2(x: Expr, y: Expr, z: Expr) -> Expr:
     """Returns ``y`` if ``x`` is not NULL. Otherwise returns ``z``.
+
+    Args:
+        x: Expression to check for NULL.
+        y: Expression to return when ``x`` is not NULL.
+        z: Expression to return when ``x`` is NULL.
 
     Examples:
         >>> ctx = dfn.SessionContext()


### PR DESCRIPTION
# Which issue does this PR close?

Related to #1463.

# Rationale for this change

Some function docstrings in `python/datafusion/functions.py` include examples but do not describe their arguments. This makes the generated API docs harder to scan when users are looking up function signatures.

This PR makes a small, focused pass over the related null-handling helpers.

# What changes are included in this PR?

Adds `Args:` sections for:

- `coalesce`
- `ifnull`
- `nanvl`
- `nvl`
- `nvl2`

# Are there any user-facing changes?

Yes, documentation-only. The generated API docs will include clearer argument descriptions for these functions. Runtime behavior is unchanged.

# Validation

- `uv tool run ruff@0.15.1 check --config pyproject.toml python/datafusion/functions.py`
  - Result: `All checks passed!`
- `uv tool run ruff@0.15.1 format --check --config pyproject.toml python/datafusion/functions.py`
  - Result: `1 file already formatted`
- `git diff --check`
  - Result: passed with no whitespace errors

# LLM-generated code disclosure

This documentation update was prepared with assistance from OpenAI Codex and manually reviewed before submission.
