### PR TITLE
fix: type scalar UDF returns as Arrow arrays

### DIFF
--- a/python/datafusion/user_defined.py
+++ b/python/datafusion/user_defined.py
@@ -33,7 +33,7 @@ from datafusion.expr import Expr
 if TYPE_CHECKING:
     from _typeshed import CapsuleType as _PyCapsule
 
-    _R = TypeVar("_R", bound=pa.DataType)
+    _R = TypeVar("_R", bound=pa.Array)
     from collections.abc import Callable, Sequence
 
 
@@ -125,7 +125,7 @@ class ScalarUDF:
         name: str,
         func: Callable[..., _R],
         input_fields: list[pa.Field],
-        return_field: _R,
+        return_field: pa.Field,
         volatility: Volatility | str,
     ) -> None:
         """Instantiate a scalar user-defined function (UDF).
@@ -264,7 +264,7 @@ class ScalarUDF:
 
         def _decorator(
             input_fields: Sequence[pa.DataType | pa.Field] | pa.DataType | pa.Field,
-            return_field: _R,
+            return_field: pa.DataType | pa.Field,
             volatility: Volatility | str,
             name: str | None = None,
         ) -> Callable:


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1516.

# Rationale for this change

The scalar UDF typing currently binds the callable return type to `pyarrow.DataType`. That makes type checkers expect UDF implementations to return a data type object, even though scalar UDF callables return Arrow arrays containing values of the declared return type.

This shows up with the existing `examples/python-udf.py` pattern, where a function annotated as returning `pa.Array` is rejected by mypy.

# What changes are included in this PR?

This PR updates the scalar UDF type hints in `python/datafusion/user_defined.py` so that:

- the UDF callable return type is bounded to `pa.Array`
- `ScalarUDF.__init__` accepts a `pa.Field` for the resolved return field
- the decorator helper accepts the public `pa.DataType | pa.Field` return-field input

Runtime behavior is unchanged.

# Are these changes tested?

Yes. I ran the following local checks:

- `uv tool run ruff@0.15.1 check --config pyproject.toml python/datafusion/user_defined.py examples/python-udf.py`
  - Result: `All checks passed!`
- `uv tool run ruff@0.15.1 format --check --config pyproject.toml python/datafusion/user_defined.py examples/python-udf.py`
  - Result: `2 files already formatted`
- `git diff --check`
  - Result: passed with no whitespace errors

# Are there any user-facing changes?

Yes, for static typing only. User-defined scalar functions that return Arrow arrays should type-check more accurately. There is no runtime API change.

# LLM-generated code disclosure

This type-hint update was prepared with assistance from OpenAI Codex and manually reviewed before submission.
