### PR TITLE
feat: create free-threaded python wheels

### DIFF
--- a/.github/actions/build-wheel/action.yml
+++ b/.github/actions/build-wheel/action.yml
@@ -89,4 +89,6 @@ runs:
     - name: Build via native maturin
       if: inputs.manylinux == ''
       shell: bash
-      run: uv run --no-project maturin build ${{ steps.args.outputs.args }}
+      # Use `uvx` so maturin is available even when `uv sync` was skipped
+      # (free-threaded matrix entries don't pre-populate the project venv).
+      run: uvx maturin@1.8.1 build ${{ steps.args.outputs.args }}

--- a/.github/actions/build-wheel/action.yml
+++ b/.github/actions/build-wheel/action.yml
@@ -1,0 +1,92 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Composite action that builds a datafusion-python wheel with maturin.
+# Centralises the abi3-vs-free-threaded argument logic so platform jobs
+# stay short and changes to wheel-build flags happen in one place.
+
+name: "Build wheel"
+description: "Build datafusion-python wheel with maturin (abi3 or free-threaded)"
+
+inputs:
+  target:
+    description: "Rust target triple (e.g. x86_64-unknown-linux-gnu). Required when manylinux is set; ignored for native builds."
+    required: false
+    default: ""
+  python-tag:
+    description: "abi3 (covers 3.10..3.14 GIL builds) or a free-threaded interpreter such as 3.13t / 3.14t"
+    required: true
+  build-mode:
+    description: "release or debug"
+    required: true
+  features:
+    description: "Comma-separated extra features (in addition to those implied by the python-tag)"
+    required: false
+    default: "substrait"
+  manylinux:
+    description: "manylinux tag for maturin-action (e.g. 2_28). Leave empty to use uv-run maturin natively."
+    required: false
+    default: ""
+  out-dir:
+    description: "Output directory for built wheels"
+    required: false
+    default: "dist"
+
+outputs:
+  args:
+    description: "Computed maturin args (for debugging)"
+    value: ${{ steps.args.outputs.args }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Compute maturin args
+      id: args
+      shell: bash
+      run: |
+        set -euo pipefail
+        FEATURES="${{ inputs.features }}"
+        TAG="${{ inputs.python-tag }}"
+        if [ "$TAG" = "abi3" ]; then
+          # Default features include the `abi3` cargo feature.
+          # One wheel covers Python 3.10..3.14 (GIL builds only).
+          BUILD_ARGS="--features ${FEATURES}"
+        else
+          # Free-threaded build: disable abi3, force mimalloc back in, pin interpreter.
+          BUILD_ARGS="--no-default-features --features mimalloc,${FEATURES} --interpreter python${TAG}"
+        fi
+        if [ "${{ inputs.build-mode }}" = "release" ]; then
+          BUILD_ARGS="--release --strip ${BUILD_ARGS}"
+        fi
+        BUILD_ARGS="${BUILD_ARGS} --out ${{ inputs.out-dir }}"
+        echo "args=${BUILD_ARGS}" >> "$GITHUB_OUTPUT"
+        echo "maturin args: ${BUILD_ARGS}"
+
+    - name: Build via maturin-action (manylinux container)
+      if: inputs.manylinux != ''
+      uses: PyO3/maturin-action@v1
+      with:
+        target: ${{ inputs.target }}
+        manylinux: ${{ inputs.manylinux }}
+        maturin-version: "1.8.1"
+        args: ${{ steps.args.outputs.args }}
+        rustup-components: rust-std
+
+    - name: Build via native maturin
+      if: inputs.manylinux == ''
+      shell: bash
+      run: uv run --no-project maturin build ${{ steps.args.outputs.args }}

--- a/.github/actions/build-wheel/action.yml
+++ b/.github/actions/build-wheel/action.yml
@@ -98,7 +98,7 @@ runs:
       with:
         target: ${{ inputs.target }}
         manylinux: ${{ inputs.manylinux }}
-        maturin-version: "1.8.1"
+        maturin-version: "1.13.3"
         args: ${{ steps.args.outputs.args }}
         rustup-components: rust-std
 
@@ -107,4 +107,4 @@ runs:
       shell: bash
       # Use `uvx` so maturin is available even when `uv sync` was skipped
       # (free-threaded matrix entries don't pre-populate the project venv).
-      run: uvx maturin@1.8.1 build ${{ steps.args.outputs.args }}
+      run: uvx maturin@1.13.3 build ${{ steps.args.outputs.args }}

--- a/.github/actions/build-wheel/action.yml
+++ b/.github/actions/build-wheel/action.yml
@@ -67,7 +67,23 @@ runs:
           BUILD_ARGS="--features ${FEATURES}"
         else
           # Free-threaded build: disable abi3, force mimalloc back in, pin interpreter.
-          BUILD_ARGS="--no-default-features --features mimalloc,${FEATURES} --interpreter python${TAG}"
+          if [ "${RUNNER_OS:-}" = "Windows" ]; then
+            # Windows free-threaded builds ship as `python.exe` (no `tN`
+            # suffix). Resolve sys.executable so the path is independent of
+            # PATH ordering, and assert the interpreter is actually
+            # free-threaded before we hand the wheel off.
+            INTERP=$(python -c 'import sys; print(sys.executable)')
+            python -c "import sysconfig, sys; \
+              v = sysconfig.get_config_var('Py_GIL_DISABLED'); \
+              sys.exit(0 if v == 1 else f'expected free-threaded interpreter, got Py_GIL_DISABLED={v!r} at {sys.executable}')"
+            # Backslashes in BUILD_ARGS would be parsed as escapes when the
+            # output is re-expanded in the next step; use forward slashes
+            # (maturin/Rust accept them on Windows).
+            INTERP="${INTERP//\\//}"
+          else
+            INTERP="python${TAG}"
+          fi
+          BUILD_ARGS="--no-default-features --features mimalloc,${FEATURES} --interpreter ${INTERP}"
         fi
         if [ "${{ inputs.build-mode }}" = "release" ]; then
           BUILD_ARGS="--release --strip ${BUILD_ARGS}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,8 +135,12 @@ jobs:
   # ============================================
   build-manylinux-x86_64:
     needs: [generate-license, lint-rust, lint-python]
-    name: ManyLinux x86_64
+    name: ManyLinux x86_64 (${{ matrix.python-tag }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-tag: ["abi3", "3.13t", "3.14t"]
     steps:
       - uses: actions/checkout@v6
 
@@ -153,7 +157,7 @@ jobs:
       - name: Cache Cargo
         uses: Swatinem/rust-cache@v2
         with:
-          key: ${{ inputs.build_mode }}
+          key: ${{ inputs.build_mode }}-${{ matrix.python-tag }}
 
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
         with:
@@ -172,25 +176,18 @@ jobs:
           free -h
           swapon --show
 
-      - name: Build (release mode)
-        uses: PyO3/maturin-action@v1
-        if: inputs.build_mode == 'release'
+      - name: Build wheel
+        uses: ./.github/actions/build-wheel
         with:
           target: x86_64-unknown-linux-gnu
+          python-tag: ${{ matrix.python-tag }}
+          build-mode: ${{ inputs.build_mode }}
+          features: "protoc,substrait"
           manylinux: "2_28"
-          args: --release --strip --features protoc,substrait --out dist
-          rustup-components: rust-std
 
-      - name: Build (debug mode)
-        uses: PyO3/maturin-action@v1
-        if: inputs.build_mode == 'debug'
-        with:
-          target: x86_64-unknown-linux-gnu
-          manylinux: "2_28"
-          args: --features protoc,substrait --out dist
-          rustup-components: rust-std
-
+      # FFI test wheel only needs to be built once per platform; gate to abi3.
       - name: Build FFI test library
+        if: matrix.python-tag == 'abi3'
         uses: PyO3/maturin-action@v1
         with:
           target: x86_64-unknown-linux-gnu
@@ -202,10 +199,11 @@ jobs:
       - name: Archive wheels
         uses: actions/upload-artifact@v7
         with:
-          name: dist-manylinux-x86_64
+          name: dist-manylinux-x86_64-${{ matrix.python-tag }}
           path: dist/*
 
       - name: Archive FFI test wheel
+        if: matrix.python-tag == 'abi3'
         uses: actions/upload-artifact@v7
         with:
           name: test-ffi-manylinux-x86_64
@@ -216,8 +214,12 @@ jobs:
   # ============================================
   build-manylinux-aarch64:
     needs: [generate-license, lint-rust, lint-python]
-    name: ManyLinux arm64
+    name: ManyLinux arm64 (${{ matrix.python-tag }})
     runs-on: ubuntu-24.04-arm
+    strategy:
+      fail-fast: false
+      matrix:
+        python-tag: ["abi3", "3.13t", "3.14t"]
     steps:
       - uses: actions/checkout@v6
 
@@ -234,7 +236,7 @@ jobs:
       - name: Cache Cargo
         uses: Swatinem/rust-cache@v2
         with:
-          key: ${{ inputs.build_mode }}
+          key: ${{ inputs.build_mode }}-${{ matrix.python-tag }}
 
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
         with:
@@ -253,29 +255,20 @@ jobs:
           free -h
           swapon --show
 
-      - name: Build (release mode)
-        uses: PyO3/maturin-action@v1
-        if: inputs.build_mode == 'release'
+      - name: Build wheel
+        uses: ./.github/actions/build-wheel
         with:
           target: aarch64-unknown-linux-gnu
+          python-tag: ${{ matrix.python-tag }}
+          build-mode: ${{ inputs.build_mode }}
+          features: "protoc,substrait"
           manylinux: "2_28"
-          args: --release --strip --features protoc,substrait --out dist
-          rustup-components: rust-std
-
-      - name: Build (debug mode)
-        uses: PyO3/maturin-action@v1
-        if: inputs.build_mode == 'debug'
-        with:
-          target: aarch64-unknown-linux-gnu
-          manylinux: "2_28"
-          args: --features protoc,substrait --out dist
-          rustup-components: rust-std
 
       - name: Archive wheels
         uses: actions/upload-artifact@v7
         if: inputs.build_mode == 'release'
         with:
-          name: dist-manylinux-aarch64
+          name: dist-manylinux-aarch64-${{ matrix.python-tag }}
           path: dist/*
 
   # ============================================
@@ -283,13 +276,13 @@ jobs:
   # ============================================
   build-python-mac-win:
     needs: [generate-license, lint-rust, lint-python]
-    name: macOS arm64 & Windows
+    name: macOS arm64 & Windows (${{ matrix.python-tag }} / ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10"]
         os: [macos-latest, windows-latest]
+        python-tag: ["abi3", "3.13t", "3.14t"]
     steps:
       - uses: actions/checkout@v6
 
@@ -305,7 +298,14 @@ jobs:
       - name: Cache Cargo
         uses: Swatinem/rust-cache@v2
         with:
-          key: ${{ inputs.build_mode }}
+          key: ${{ inputs.build_mode }}-${{ matrix.python-tag }}
+
+      - name: Setup Python (free-threaded)
+        if: matrix.python-tag != 'abi3'
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-tag }}
+          freethreaded: true
 
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
         with:
@@ -318,22 +318,22 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install dependencies
+        if: matrix.python-tag == 'abi3'
         run: uv sync --dev --no-install-package datafusion
 
-      # Run clippy BEFORE maturin so we can avoid rebuilding. The features must match
-      # exactly the features used by maturin. Linux maturin builds need to happen in a
-      # container so only run this for our mac runner.
+      # Clippy is interpreter-agnostic; run once per OS (against the abi3 entry)
+      # so the matrix doesn't pay the cost three times.
       - name: Run Clippy
-        if: matrix.os != 'windows-latest'
+        if: matrix.os != 'windows-latest' && matrix.python-tag == 'abi3'
         run: cargo clippy --no-deps --all-targets --features substrait -- -D warnings
 
-      - name: Build Python package (release mode)
-        if: inputs.build_mode == 'release'
-        run: uv run --no-project maturin build --release --strip --features substrait
-
-      - name: Build Python package (debug mode)
-        if: inputs.build_mode != 'release'
-        run: uv run --no-project maturin build --features substrait
+      - name: Build wheel
+        uses: ./.github/actions/build-wheel
+        with:
+          python-tag: ${{ matrix.python-tag }}
+          build-mode: ${{ inputs.build_mode }}
+          features: "substrait"
+          out-dir: "target/wheels"
 
       - name: List Windows wheels
         if: matrix.os == 'windows-latest'
@@ -350,7 +350,7 @@ jobs:
         uses: actions/upload-artifact@v7
         if: inputs.build_mode == 'release'
         with:
-          name: dist-${{ matrix.os  }}
+          name: dist-${{ matrix.os }}-${{ matrix.python-tag }}
           path: target/wheels/*
 
   # ============================================
@@ -359,11 +359,12 @@ jobs:
   build-macos-x86_64:
     if: inputs.build_mode == 'release'
     needs: [generate-license, lint-rust, lint-python]
+    name: macOS x86_64 (${{ matrix.python-tag }})
     runs-on: macos-15-intel
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10"]
+        python-tag: ["abi3", "3.13t", "3.14t"]
     steps:
       - uses: actions/checkout@v6
 
@@ -379,7 +380,14 @@ jobs:
       - name: Cache Cargo
         uses: Swatinem/rust-cache@v2
         with:
-          key: ${{ inputs.build_mode }}
+          key: ${{ inputs.build_mode }}-${{ matrix.python-tag }}
+
+      - name: Setup Python (free-threaded)
+        if: matrix.python-tag != 'abi3'
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-tag }}
+          freethreaded: true
 
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
         with:
@@ -392,11 +400,16 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install dependencies
+        if: matrix.python-tag == 'abi3'
         run: uv sync --dev --no-install-package datafusion
 
-      - name: Build (release mode)
-        run: |
-          uv run --no-project maturin build --release --strip --features substrait
+      - name: Build wheel
+        uses: ./.github/actions/build-wheel
+        with:
+          python-tag: ${{ matrix.python-tag }}
+          build-mode: ${{ inputs.build_mode }}
+          features: "substrait"
+          out-dir: "target/wheels"
 
       - name: List Mac wheels
         run: find target/wheels/
@@ -404,7 +417,7 @@ jobs:
       - name: Archive wheels
         uses: actions/upload-artifact@v7
         with:
-          name: dist-macos-aarch64
+          name: dist-macos-aarch64-${{ matrix.python-tag }}
           path: target/wheels/*
 
   # ============================================
@@ -509,11 +522,12 @@ jobs:
         with:
           enable-cache: true
 
-      # Download the Linux wheel built in the previous job
+      # Download the Linux wheel built in the previous job.
+      # Docs only need the abi3 wheel — interpreter doesn't matter for sphinx.
       - name: Download pre-built Linux wheel
         uses: actions/download-artifact@v8
         with:
-          name: dist-manylinux-x86_64
+          name: dist-manylinux-x86_64-abi3
           path: wheels/
 
       # Install from the pre-built wheels

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,7 +135,7 @@ jobs:
   # ============================================
   build-manylinux-x86_64:
     needs: [generate-license, lint-rust, lint-python]
-    name: ManyLinux x86_64 (${{ matrix.python-tag }})
+    name: Linux x86_64 (${{ matrix.python-tag }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -214,7 +214,7 @@ jobs:
   # ============================================
   build-manylinux-aarch64:
     needs: [generate-license, lint-rust, lint-python]
-    name: ManyLinux arm64 (${{ matrix.python-tag }})
+    name: Linux arm64 (${{ matrix.python-tag }})
     runs-on: ubuntu-24.04-arm
     strategy:
       fail-fast: false
@@ -276,7 +276,7 @@ jobs:
   # ============================================
   build-python-mac-win:
     needs: [generate-license, lint-rust, lint-python]
-    name: macOS arm64 & Windows (${{ matrix.python-tag }} / ${{ matrix.os }})
+    name: ${{ matrix.os == 'macos-latest' && 'macOS arm64' || 'Windows x86_64' }} (${{ matrix.python-tag }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,16 +79,17 @@ jobs:
           path: wheels/
 
       - name: Install from pre-built wheels
-        env:
-          # Pin every uv command to the interpreter from setup-python.
-          # Without this, `uv sync` ignores the existing .venv, runs its
-          # own discovery, and grabs the system 3.12, producing a
-          # wheel/ABI mismatch on free-threaded jobs.
-          UV_PYTHON: ${{ steps.setup-python.outputs.python-path }}
         run: |
           set -x
-          uv venv
-          uv sync --dev --no-install-package datafusion
+          # Create the venv with the setup-python interpreter, then activate
+          # it so every uv command targets that same .venv. Using UV_PYTHON
+          # instead diverges: `uv sync` populates .venv while `uv pip install`
+          # targets the bare interpreter, so the datafusion wheel never lands
+          # in .venv. `--active` stops `uv sync` from discovering and
+          # recreating the env with the system 3.12.
+          uv venv --python "${{ steps.setup-python.outputs.python-path }}"
+          source .venv/bin/activate
+          uv sync --active --dev --no-install-package datafusion
           WHEELS=$(find wheels/ -name "*.whl")
           if [ -n "$WHEELS" ]; then
             echo "Installing wheels:"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,7 +102,6 @@ jobs:
       - name: Run tests
         env:
           RUST_BACKTRACE: 1
-          UV_PYTHON: ${{ steps.setup-python.outputs.python-path }}
           # On free-threaded interpreters, fail loud if any C extension
           # re-enables the GIL implicitly.
           PYTHON_GIL: ${{ matrix.freethreaded && '0' || '' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,20 +81,21 @@ jobs:
       - name: Install from pre-built wheels
         run: |
           set -x
-          # Create the venv with the setup-python interpreter, then activate
-          # it so every uv command targets that same .venv. Using UV_PYTHON
-          # instead diverges: `uv sync` populates .venv while `uv pip install`
-          # targets the bare interpreter, so the datafusion wheel never lands
-          # in .venv. `--active` stops `uv sync` from discovering and
-          # recreating the env with the system 3.12.
+          # Create the venv with the setup-python interpreter, then point
+          # every uv command explicitly at the venv's own interpreter.
+          # uv's interpreter discovery skips free-threaded builds unless
+          # asked by exact path, so plain `uv sync` (even with an activated
+          # venv or --active) re-picks the system 3.12 and recreates .venv.
+          # Targeting .venv/bin/python keeps sync and pip install in the
+          # same 3.13t/3.14t environment as the cp313t/cp314t wheel.
           uv venv --python "${{ steps.setup-python.outputs.python-path }}"
-          source .venv/bin/activate
-          uv sync --active --dev --no-install-package datafusion
+          VENV_PY="$PWD/.venv/bin/python"
+          uv sync --python "$VENV_PY" --dev --no-install-package datafusion
           WHEELS=$(find wheels/ -name "*.whl")
           if [ -n "$WHEELS" ]; then
             echo "Installing wheels:"
             echo "$WHEELS"
-            uv pip install wheels/*.whl
+            uv pip install --python "$VENV_PY" wheels/*.whl
           else
             echo "ERROR: No wheels found!"
             exit 1
@@ -108,7 +109,9 @@ jobs:
           PYTHON_GIL: ${{ matrix.freethreaded && '0' || '' }}
         run: |
           git submodule update --init
-          uv run --no-project pytest -v --import-mode=importlib
+          # Use the .venv interpreter directly; uv discovery would skip the
+          # free-threaded build and re-pick the system 3.12 (see install step).
+          uv run --python "$PWD/.venv/bin/python" --no-project pytest -v --import-mode=importlib
 
       # FFI + TPC-H examples only need to run once; gate to abi3 entries.
       - name: FFI unit tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,6 +47,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Setup Python
+        id: setup-python
         uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
@@ -80,7 +81,10 @@ jobs:
       - name: Install from pre-built wheels
         run: |
           set -x
-          uv venv --python ${{ matrix.python-version }}
+          # Use the interpreter installed by setup-python. Passing a bare
+          # version like "3.13t" lets uv fall back to a different system
+          # interpreter (e.g. 3.12), producing a wheel/ABI mismatch.
+          uv venv --python "${{ steps.setup-python.outputs.python-path }}"
           uv sync --dev --no-install-package datafusion
           WHEELS=$(find wheels/ -name "*.whl")
           if [ -n "$WHEELS" ]; then

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,12 +79,15 @@ jobs:
           path: wheels/
 
       - name: Install from pre-built wheels
+        env:
+          # Pin every uv command to the interpreter from setup-python.
+          # Without this, `uv sync` ignores the existing .venv, runs its
+          # own discovery, and grabs the system 3.12, producing a
+          # wheel/ABI mismatch on free-threaded jobs.
+          UV_PYTHON: ${{ steps.setup-python.outputs.python-path }}
         run: |
           set -x
-          # Use the interpreter installed by setup-python. Passing a bare
-          # version like "3.13t" lets uv fall back to a different system
-          # interpreter (e.g. 3.12), producing a wheel/ABI mismatch.
-          uv venv --python "${{ steps.setup-python.outputs.python-path }}"
+          uv venv
           uv sync --dev --no-install-package datafusion
           WHEELS=$(find wheels/ -name "*.whl")
           if [ -n "$WHEELS" ]; then
@@ -99,6 +102,7 @@ jobs:
       - name: Run tests
         env:
           RUST_BACKTRACE: 1
+          UV_PYTHON: ${{ steps.setup-python.outputs.python-path }}
           # On free-threaded interpreters, fail loud if any C extension
           # re-enables the GIL implicitly.
           PYTHON_GIL: ${{ matrix.freethreaded && '0' || '' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,8 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# Reusable workflow for running tests
-# This ensures the same tests run for both debug (PRs) and release (main/tags) builds
+# Reusable workflow for running tests.
+# Single matrix covers both GIL (abi3 wheel) and free-threaded
+# (per-interpreter wheels) builds.
 
 name: Test
 
@@ -32,15 +33,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version:
-          - "3.10"
-          - "3.11"
-          - "3.12"
-          - "3.13"
-          - "3.14"
-        toolchain:
-          - "stable"
-
+        include:
+          # GIL builds — all share the same abi3 wheel.
+          - { python-version: "3.10", wheel-tag: "abi3", freethreaded: false }
+          - { python-version: "3.11", wheel-tag: "abi3", freethreaded: false }
+          - { python-version: "3.12", wheel-tag: "abi3", freethreaded: false }
+          - { python-version: "3.13", wheel-tag: "abi3", freethreaded: false }
+          - { python-version: "3.14", wheel-tag: "abi3", freethreaded: false }
+          # Free-threaded builds — one wheel per interpreter.
+          - { python-version: "3.13t", wheel-tag: "3.13t", freethreaded: true }
+          - { python-version: "3.14t", wheel-tag: "3.14t", freethreaded: true }
     steps:
       - uses: actions/checkout@v6
 
@@ -48,40 +50,38 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
+          freethreaded: ${{ matrix.freethreaded }}
 
       - name: Cache Cargo
         uses: actions/cache@v5
         with:
           path: ~/.cargo
-          key: cargo-cache-${{ matrix.toolchain }}-${{ hashFiles('Cargo.lock') }}
+          key: cargo-cache-stable-${{ hashFiles('Cargo.lock') }}
 
       - name: Install dependencies
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
         with:
           enable-cache: true
 
-      # Download the Linux wheel built in the build workflow
       - name: Download pre-built Linux wheel
         uses: actions/download-artifact@v8
         with:
-          name: dist-manylinux-x86_64
+          name: dist-manylinux-x86_64-${{ matrix.wheel-tag }}
           path: wheels/
 
-      # Download the FFI test wheel
+      # FFI test wheel only built once (under the abi3 matrix entry in build.yml).
       - name: Download pre-built FFI test wheel
+        if: matrix.wheel-tag == 'abi3'
         uses: actions/download-artifact@v8
         with:
           name: test-ffi-manylinux-x86_64
           path: wheels/
 
-      # Install from the pre-built wheels
       - name: Install from pre-built wheels
         run: |
           set -x
-          uv venv
-          # Install development dependencies
+          uv venv --python ${{ matrix.python-version }}
           uv sync --dev --no-install-package datafusion
-          # Install all pre-built wheels
           WHEELS=$(find wheels/ -name "*.whl")
           if [ -n "$WHEELS" ]; then
             echo "Installing wheels:"
@@ -95,16 +95,22 @@ jobs:
       - name: Run tests
         env:
           RUST_BACKTRACE: 1
+          # On free-threaded interpreters, fail loud if any C extension
+          # re-enables the GIL implicitly.
+          PYTHON_GIL: ${{ matrix.freethreaded && '0' || '' }}
         run: |
           git submodule update --init
           uv run --no-project pytest -v --import-mode=importlib
 
+      # FFI + TPC-H examples only need to run once; gate to abi3 entries.
       - name: FFI unit tests
+        if: matrix.wheel-tag == 'abi3'
         run: |
           cd examples/datafusion-ffi-example
           uv run --no-project pytest python/tests/_test*.py
 
       - name: Run tpchgen-cli to create 1 Gb dataset
+        if: matrix.wheel-tag == 'abi3'
         run: |
           mkdir examples/tpch/data
           cd examples/tpch/data
@@ -112,6 +118,7 @@ jobs:
           uv run --no-project tpchgen-cli -s 1 --format=parquet
 
       - name: Run TPC-H examples
+        if: matrix.wheel-tag == 'abi3'
         run: |
           cd examples/tpch
           uv run --no-project pytest _tests.py

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2928,6 +2928,7 @@ version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bf94ee265674bf76c09fa430b0e99c26e319c945d96ca0d5a8215f31bf81cf7"
 dependencies = [
+ "python3-dll-a",
  "target-lexicon",
 ]
 
@@ -2975,6 +2976,15 @@ dependencies = [
  "pyo3-build-config",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "python3-dll-a"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d80ba7540edb18890d444c5aa8e1f1f99b1bdf26fb26ae383135325f4a36042b"
+dependencies = [
+ "cc",
 ]
 
 [[package]]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -40,7 +40,10 @@ tokio = { workspace = true, features = [
   "rt-multi-thread",
   "sync",
 ] }
-pyo3 = { workspace = true, features = ["extension-module", "generate-import-lib"] }
+pyo3 = { workspace = true, features = [
+  "extension-module",
+  "generate-import-lib",
+] }
 pyo3-async-runtimes = { workspace = true, features = ["tokio-runtime"] }
 pyo3-log = { workspace = true }
 chrono = { workspace = true }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -40,11 +40,7 @@ tokio = { workspace = true, features = [
   "rt-multi-thread",
   "sync",
 ] }
-pyo3 = { workspace = true, features = [
-  "extension-module",
-  "abi3",
-  "abi3-py310",
-] }
+pyo3 = { workspace = true, features = ["extension-module"] }
 pyo3-async-runtimes = { workspace = true, features = ["tokio-runtime"] }
 pyo3-log = { workspace = true }
 chrono = { workspace = true }
@@ -74,7 +70,11 @@ prost-types = { workspace = true }
 pyo3-build-config = { workspace = true }
 
 [features]
-default = ["mimalloc"]
+default = ["mimalloc", "abi3"]
+# Stable ABI build — single wheel covers Python 3.10..3.14 (GIL builds only).
+# Mutually exclusive with free-threaded interpreters (cp313t / cp314t); the
+# free-threaded wheel build must pass --no-default-features.
+abi3 = ["pyo3/abi3", "pyo3/abi3-py310"]
 protoc = ["datafusion-substrait/protoc"]
 substrait = ["dep:datafusion-substrait"]
 

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -40,7 +40,7 @@ tokio = { workspace = true, features = [
   "rt-multi-thread",
   "sync",
 ] }
-pyo3 = { workspace = true, features = ["extension-module"] }
+pyo3 = { workspace = true, features = ["extension-module", "generate-import-lib"] }
 pyo3-async-runtimes = { workspace = true, features = ["tokio-runtime"] }
 pyo3-log = { workspace = true }
 chrono = { workspace = true }

--- a/dev/release/README.md
+++ b/dev/release/README.md
@@ -75,6 +75,7 @@ We maintain a `CHANGELOG.md` so our users know what has been changed between rel
 The changelog is generated using a Python script:
 
 ```bash
+$ uv sync --group release
 $ GITHUB_TOKEN=<TOKEN> ./dev/release/generate-changelog.py 52.0.0 HEAD 53.0.0 > dev/changelog/53.0.0.md
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -202,12 +202,17 @@ dev = [
   "numpy>=2.3.2;python_version>='3.14'",
   "pre-commit>=4.3.0",
   "pyarrow>=19.0.0",
-  "pygithub==2.5.0",
   "pytest-asyncio>=0.23.3",
   "pytest>=7.4.4",
   "pyyaml>=6.0.3",
   "ruff>=0.15.1",
   "toml>=0.10.2",
+]
+# Release tooling only. Kept out of `dev` because pygithub pulls in
+# cryptography, which ships no free-threaded wheel and fails to build
+# from sdist under free-threaded interpreters (PyO3 < 3.14 support).
+release = [
+  "pygithub==2.5.0",
 ]
 docs = [
   "ipython>=8.12.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
+  "Programming Language :: Python :: Free Threading :: 2 - Beta",
   "Programming Language :: Python",
   "Programming Language :: Rust",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -211,9 +211,7 @@ dev = [
 # Release tooling only. Kept out of `dev` because pygithub pulls in
 # cryptography, which ships no free-threaded wheel and fails to build
 # from sdist under free-threaded interpreters (PyO3 < 3.14 support).
-release = [
-  "pygithub==2.5.0",
-]
+release = ["pygithub==2.5.0"]
 docs = [
   "ipython>=8.12.3",
   "jinja2>=3.1.5",

--- a/uv.lock
+++ b/uv.lock
@@ -340,7 +340,6 @@ dev = [
     { name = "numpy", version = "2.3.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "pre-commit" },
     { name = "pyarrow" },
-    { name = "pygithub" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pyyaml" },
@@ -357,6 +356,9 @@ docs = [
     { name = "setuptools" },
     { name = "sphinx" },
     { name = "sphinx-autoapi" },
+]
+release = [
+    { name = "pygithub" },
 ]
 
 [package.metadata]
@@ -377,7 +379,6 @@ dev = [
     { name = "numpy", marker = "python_full_version >= '3.14'", specifier = ">=2.3.2" },
     { name = "pre-commit", specifier = ">=4.3.0" },
     { name = "pyarrow", specifier = ">=19.0.0" },
-    { name = "pygithub", specifier = "==2.5.0" },
     { name = "pytest", specifier = ">=7.4.4" },
     { name = "pytest-asyncio", specifier = ">=0.23.3" },
     { name = "pyyaml", specifier = ">=6.0.3" },
@@ -395,6 +396,7 @@ docs = [
     { name = "sphinx", specifier = ">=7.1.2" },
     { name = "sphinx-autoapi", specifier = ">=3.4.0" },
 ]
+release = [{ name = "pygithub", specifier = "==2.5.0" }]
 
 [[package]]
 name = "decorator"


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1324

 # Rationale for this change

Starting in Python 3.14 free-threaded support is no longer experimental.

# What changes are included in this PR?

Update build to support free-threaded Python wheels.

# Are there any user-facing changes?

None