### PR TITLE
feat: expose variety of features from DF54 update

### DIFF
--- a/.ai/skills/check-upstream/SKILL.md
+++ b/.ai/skills/check-upstream/SKILL.md
@@ -66,11 +66,17 @@ The user may specify an area via `$ARGUMENTS`. If no area is specified or "all" 
 - Python API: `python/datafusion/functions.py` — each function wraps a call to `datafusion._internal.functions`
 - Rust bindings: `crates/core/src/functions.rs` — `#[pyfunction]` definitions registered via `init_module()`
 
+**Evaluated and not requiring separate Python exposure:**
+- `get_field_path` — already covered by `get_field(expr, *names)`, which takes a
+  variadic field path and dispatches to the same underlying
+  `functions::core::get_field` UDF as the upstream `get_field_path` helper.
+
 **How to check:**
 1. Fetch the upstream scalar function documentation page
 2. Compare against functions listed in `python/datafusion/functions.py` (check the `__all__` list and function definitions)
 3. A function is covered if it exists in the Python API — it does NOT need a dedicated Rust `#[pyfunction]`. Many functions are aliases that reuse another function's Rust binding.
-4. Only report functions that are missing from the Python `__all__` list / function definitions
+4. Check against the "evaluated and not requiring exposure" list before flagging as a gap
+5. Only report functions that are missing from the Python `__all__` list / function definitions
 
 ### 2. Aggregate Functions
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@
 
 repos:
       - repo: https://github.com/rhysd/actionlint
-        rev: v1.7.6
+        rev: v1.7.12
         hooks:
           - id: actionlint-docker
       - repo: https://github.com/astral-sh/ruff-pre-commit

--- a/crates/core/src/context.rs
+++ b/crates/core/src/context.rs
@@ -35,7 +35,6 @@ use datafusion::datasource::listing::{
     ListingOptions, ListingTable, ListingTableConfig, ListingTableUrl,
 };
 use datafusion::datasource::{MemTable, TableProvider};
-use datafusion::execution::TaskContextProvider;
 use datafusion::execution::context::{
     DataFilePaths, SQLOptions, SessionConfig, SessionContext, TaskContext,
 };
@@ -44,6 +43,7 @@ use datafusion::execution::memory_pool::{FairSpillPool, GreedyMemoryPool, Unboun
 use datafusion::execution::options::{ArrowReadOptions, ReadOptions};
 use datafusion::execution::runtime_env::RuntimeEnvBuilder;
 use datafusion::execution::session_state::SessionStateBuilder;
+use datafusion::execution::{FunctionRegistry, TaskContextProvider};
 use datafusion::prelude::{
     AvroReadOptions, CsvReadOptions, DataFrame, JsonReadOptions, ParquetReadOptions,
 };
@@ -1070,6 +1070,39 @@ impl PySessionContext {
 
     pub fn deregister_udwf(&self, name: &str) {
         self.ctx.deregister_udwf(name);
+    }
+
+    pub fn udf(&self, name: &str) -> PyDataFusionResult<PyScalarUDF> {
+        let function = (*self.ctx.udf(name)?).clone();
+        Ok(PyScalarUDF { function })
+    }
+
+    pub fn udaf(&self, name: &str) -> PyDataFusionResult<PyAggregateUDF> {
+        let function = (*self.ctx.udaf(name)?).clone();
+        Ok(PyAggregateUDF { function })
+    }
+
+    pub fn udwf(&self, name: &str) -> PyDataFusionResult<PyWindowUDF> {
+        let function = (*self.ctx.udwf(name)?).clone();
+        Ok(PyWindowUDF { function })
+    }
+
+    pub fn udfs(&self) -> Vec<String> {
+        let mut names: Vec<String> = self.ctx.udfs().into_iter().collect();
+        names.sort();
+        names
+    }
+
+    pub fn udafs(&self) -> Vec<String> {
+        let mut names: Vec<String> = self.ctx.udafs().into_iter().collect();
+        names.sort();
+        names
+    }
+
+    pub fn udwfs(&self) -> Vec<String> {
+        let mut names: Vec<String> = self.ctx.udwfs().into_iter().collect();
+        names.sort();
+        names
     }
 
     #[pyo3(signature = (name="datafusion"))]

--- a/crates/core/src/context.rs
+++ b/crates/core/src/context.rs
@@ -1072,18 +1072,27 @@ impl PySessionContext {
         self.ctx.deregister_udwf(name);
     }
 
-    pub fn udf(&self, name: &str) -> PyDataFusionResult<PyScalarUDF> {
-        let function = (*self.ctx.udf(name)?).clone();
+    pub fn udf(&self, name: &str) -> PyResult<PyScalarUDF> {
+        if !self.ctx.udfs().contains(name) {
+            return Err(PyKeyError::new_err(format!("no UDF named '{name}'")));
+        }
+        let function = (*self.ctx.udf(name).map_err(py_datafusion_err)?).clone();
         Ok(PyScalarUDF { function })
     }
 
-    pub fn udaf(&self, name: &str) -> PyDataFusionResult<PyAggregateUDF> {
-        let function = (*self.ctx.udaf(name)?).clone();
+    pub fn udaf(&self, name: &str) -> PyResult<PyAggregateUDF> {
+        if !self.ctx.udafs().contains(name) {
+            return Err(PyKeyError::new_err(format!("no UDAF named '{name}'")));
+        }
+        let function = (*self.ctx.udaf(name).map_err(py_datafusion_err)?).clone();
         Ok(PyAggregateUDF { function })
     }
 
-    pub fn udwf(&self, name: &str) -> PyDataFusionResult<PyWindowUDF> {
-        let function = (*self.ctx.udwf(name)?).clone();
+    pub fn udwf(&self, name: &str) -> PyResult<PyWindowUDF> {
+        if !self.ctx.udwfs().contains(name) {
+            return Err(PyKeyError::new_err(format!("no UDWF named '{name}'")));
+        }
+        let function = (*self.ctx.udwf(name).map_err(py_datafusion_err)?).clone();
         Ok(PyWindowUDF { function })
     }
 

--- a/crates/core/src/context.rs
+++ b/crates/core/src/context.rs
@@ -847,6 +847,13 @@ impl PySessionContext {
         Ok(())
     }
 
+    pub fn read_batches(
+        &self,
+        batches: PyArrowType<Vec<RecordBatch>>,
+    ) -> PyDataFusionResult<PyDataFrame> {
+        Ok(PyDataFrame::new(self.ctx.read_batches(batches.0)?))
+    }
+
     #[allow(clippy::too_many_arguments)]
     #[pyo3(signature = (name, path, table_partition_cols=vec![],
                         parquet_pruning=true,

--- a/crates/core/src/functions.rs
+++ b/crates/core/src/functions.rs
@@ -574,10 +574,10 @@ expr_fn!(union_tag, arg1);
 expr_fn!(random);
 
 #[pyfunction]
-fn get_field(expr: PyExpr, name: PyExpr) -> PyExpr {
-    functions::core::get_field()
-        .call(vec![expr.into(), name.into()])
-        .into()
+fn get_field(expr: PyExpr, names: Vec<PyExpr>) -> PyExpr {
+    let mut args = vec![expr.into()];
+    args.extend(names.into_iter().map(Into::into));
+    functions::core::get_field().call(args).into()
 }
 
 #[pyfunction]

--- a/examples/datafusion-ffi-example/src/table_function.rs
+++ b/examples/datafusion-ffi-example/src/table_function.rs
@@ -17,9 +17,8 @@
 
 use std::sync::Arc;
 
-use datafusion_catalog::{TableFunctionImpl, TableProvider};
+use datafusion_catalog::{TableFunctionArgs, TableFunctionImpl, TableProvider};
 use datafusion_common::error::Result as DataFusionResult;
-use datafusion_expr::Expr;
 use datafusion_ffi::udtf::FFI_TableFunction;
 use datafusion_python_util::ffi_logical_codec_from_pycapsule;
 use pyo3::types::PyCapsule;
@@ -59,7 +58,7 @@ impl MyTableFunction {
 }
 
 impl TableFunctionImpl for MyTableFunction {
-    fn call(&self, _args: &[Expr]) -> DataFusionResult<Arc<dyn TableProvider>> {
+    fn call_with_args(&self, _args: TableFunctionArgs) -> DataFusionResult<Arc<dyn TableProvider>> {
         let provider = MyTableProvider::new(4, 3, 2).create_table()?;
         Ok(Arc::new(provider))
     }

--- a/python/datafusion/context.py
+++ b/python/datafusion/context.py
@@ -962,6 +962,45 @@ class SessionContext:
         """
         self.ctx.register_record_batches(name, partitions)
 
+    def read_batch(self, batch: pa.RecordBatch) -> DataFrame:
+        """Return a :py:class:`~datafusion.DataFrame` reading a single batch.
+
+        Convenience wrapper around :py:meth:`read_batches` for the single-batch
+        case. Unlike :py:meth:`register_batch`, this does not register the
+        batch as a named table; it returns an anonymous
+        :py:class:`~datafusion.DataFrame` directly.
+
+        Args:
+            batch: Record batch to wrap as a DataFrame.
+
+        Examples:
+            >>> ctx = dfn.SessionContext()
+            >>> batch = pa.RecordBatch.from_pydict({"a": [1, 2, 3]})
+            >>> ctx.read_batch(batch).to_pydict()
+            {'a': [1, 2, 3]}
+        """
+        return self.read_batches([batch])
+
+    def read_batches(self, batches: list[pa.RecordBatch]) -> DataFrame:
+        """Return a :py:class:`~datafusion.DataFrame` reading the given batches.
+
+        All batches must share the same schema. Unlike
+        :py:meth:`register_record_batches`, this does not register the batches
+        as a named table; it returns an anonymous
+        :py:class:`~datafusion.DataFrame` directly.
+
+        Args:
+            batches: Record batches to wrap as a DataFrame.
+
+        Examples:
+            >>> ctx = dfn.SessionContext()
+            >>> b1 = pa.RecordBatch.from_pydict({"a": [1, 2]})
+            >>> b2 = pa.RecordBatch.from_pydict({"a": [3, 4]})
+            >>> ctx.read_batches([b1, b2]).to_pydict()
+            {'a': [1, 2, 3, 4]}
+        """
+        return DataFrame(self.ctx.read_batches(batches))
+
     def register_parquet(
         self,
         name: str,

--- a/python/datafusion/context.py
+++ b/python/datafusion/context.py
@@ -1938,10 +1938,9 @@ class SessionContext:
     ) -> SessionContext:
         """Create a new session context with specified codec.
 
-        This only supports codecs that have been implemented using the
-        FFI interface. ``codec`` must either be a raw ``FFI_LogicalExtensionCodec``
-        ``PyCapsule`` or an object exposing
-        ``__datafusion_logical_extension_codec__``.
+        Only FFI codecs are supported. Pass any object implementing
+        ``__datafusion_logical_extension_codec__`` (see
+        :py:class:`~datafusion.user_defined.LogicalExtensionCodecExportable`).
         """
         new_internal = self.ctx.with_logical_extension_codec(codec)
         new = SessionContext.__new__(SessionContext)
@@ -1957,10 +1956,9 @@ class SessionContext:
     ) -> SessionContext:
         """Create a new session context with the specified physical codec.
 
-        This only supports codecs that have been implemented using the
-        FFI interface. ``codec`` must either be a raw
-        ``FFI_PhysicalExtensionCodec`` ``PyCapsule`` or an object exposing
-        ``__datafusion_physical_extension_codec__``.
+        Only FFI codecs are supported. Pass any object implementing
+        ``__datafusion_physical_extension_codec__`` (see
+        :py:class:`~datafusion.user_defined.PhysicalExtensionCodecExportable`).
         """
         new_internal = self.ctx.with_physical_extension_codec(codec)
         new = SessionContext.__new__(SessionContext)

--- a/python/datafusion/context.py
+++ b/python/datafusion/context.py
@@ -82,7 +82,7 @@ from ._internal import expr as expr_internal
 
 if TYPE_CHECKING:
     import pathlib
-    from collections.abc import Sequence
+    from collections.abc import Iterable, Sequence
 
     import pandas as pd
     import polars as pl  # type: ignore[import]
@@ -981,13 +981,15 @@ class SessionContext:
         """
         return self.read_batches([batch])
 
-    def read_batches(self, batches: list[pa.RecordBatch]) -> DataFrame:
+    def read_batches(self, batches: Iterable[pa.RecordBatch]) -> DataFrame:
         """Return a :py:class:`~datafusion.DataFrame` reading the given batches.
 
-        All batches must share the same schema. Unlike
-        :py:meth:`register_record_batches`, this does not register the batches
-        as a named table; it returns an anonymous
-        :py:class:`~datafusion.DataFrame` directly.
+        All batches must share the same schema. Any iterable of
+        :py:class:`pa.RecordBatch` is accepted (list, tuple, generator);
+        it is materialized into a list before being handed to the
+        underlying Rust binding. Unlike :py:meth:`register_record_batches`,
+        this does not register the batches as a named table; it returns
+        an anonymous :py:class:`~datafusion.DataFrame` directly.
 
         Args:
             batches: Record batches to wrap as a DataFrame.
@@ -998,8 +1000,13 @@ class SessionContext:
             >>> b2 = pa.RecordBatch.from_pydict({"a": [3, 4]})
             >>> ctx.read_batches([b1, b2]).to_pydict()
             {'a': [1, 2, 3, 4]}
+
+            A generator works too:
+
+            >>> ctx.read_batches(b for b in [b1, b2]).to_pydict()
+            {'a': [1, 2, 3, 4]}
         """
-        return DataFrame(self.ctx.read_batches(batches))
+        return DataFrame(self.ctx.read_batches(list(batches)))
 
     def register_parquet(
         self,

--- a/python/datafusion/context.py
+++ b/python/datafusion/context.py
@@ -86,6 +86,7 @@ if TYPE_CHECKING:
 
     import pandas as pd
     import polars as pl  # type: ignore[import]
+    from _typeshed import CapsuleType as _PyCapsule
 
     from datafusion.catalog import CatalogProvider, Table
     from datafusion.common import DFSchema
@@ -93,6 +94,8 @@ if TYPE_CHECKING:
     from datafusion.plan import ExecutionPlan, LogicalPlan
     from datafusion.user_defined import (
         AggregateUDF,
+        LogicalExtensionCodecExportable,
+        PhysicalExtensionCodecExportable,
         ScalarUDF,
         TableFunction,
         WindowUDF,
@@ -1744,11 +1747,15 @@ class SessionContext:
         """Access the PyCapsule FFI_LogicalExtensionCodec."""
         return self.ctx.__datafusion_logical_extension_codec__()
 
-    def with_logical_extension_codec(self, codec: Any) -> SessionContext:
+    def with_logical_extension_codec(
+        self, codec: LogicalExtensionCodecExportable | _PyCapsule
+    ) -> SessionContext:
         """Create a new session context with specified codec.
 
         This only supports codecs that have been implemented using the
-        FFI interface.
+        FFI interface. ``codec`` must either be a raw ``FFI_LogicalExtensionCodec``
+        ``PyCapsule`` or an object exposing
+        ``__datafusion_logical_extension_codec__``.
         """
         new_internal = self.ctx.with_logical_extension_codec(codec)
         new = SessionContext.__new__(SessionContext)
@@ -1759,11 +1766,15 @@ class SessionContext:
         """Access the PyCapsule FFI_PhysicalExtensionCodec."""
         return self.ctx.__datafusion_physical_extension_codec__()
 
-    def with_physical_extension_codec(self, codec: Any) -> SessionContext:
+    def with_physical_extension_codec(
+        self, codec: PhysicalExtensionCodecExportable | _PyCapsule
+    ) -> SessionContext:
         """Create a new session context with the specified physical codec.
 
         This only supports codecs that have been implemented using the
-        FFI interface.
+        FFI interface. ``codec`` must either be a raw
+        ``FFI_PhysicalExtensionCodec`` ``PyCapsule`` or an object exposing
+        ``__datafusion_physical_extension_codec__``.
         """
         new_internal = self.ctx.with_physical_extension_codec(codec)
         new = SessionContext.__new__(SessionContext)

--- a/python/datafusion/context.py
+++ b/python/datafusion/context.py
@@ -1310,6 +1310,65 @@ class SessionContext:
         """
         self.ctx.deregister_udwf(name)
 
+    def udf(self, name: str) -> ScalarUDF:
+        """Look up a registered scalar UDF by name.
+
+        Args:
+            name: Name of the registered scalar UDF.
+
+        Raises:
+            Exception: If no scalar UDF is registered under ``name``.
+        """
+        from datafusion.user_defined import ScalarUDF as _ScalarUDF  # noqa: PLC0415
+
+        wrapper = _ScalarUDF.__new__(_ScalarUDF)
+        wrapper._udf = self.ctx.udf(name)
+        return wrapper
+
+    def udaf(self, name: str) -> AggregateUDF:
+        """Look up a registered aggregate UDF by name.
+
+        Args:
+            name: Name of the registered aggregate UDF.
+
+        Raises:
+            Exception: If no aggregate UDF is registered under ``name``.
+        """
+        from datafusion.user_defined import (  # noqa: PLC0415
+            AggregateUDF as _AggregateUDF,
+        )
+
+        wrapper = _AggregateUDF.__new__(_AggregateUDF)
+        wrapper._udaf = self.ctx.udaf(name)
+        return wrapper
+
+    def udwf(self, name: str) -> WindowUDF:
+        """Look up a registered window UDF by name.
+
+        Args:
+            name: Name of the registered window UDF.
+
+        Raises:
+            Exception: If no window UDF is registered under ``name``.
+        """
+        from datafusion.user_defined import WindowUDF as _WindowUDF  # noqa: PLC0415
+
+        wrapper = _WindowUDF.__new__(_WindowUDF)
+        wrapper._udwf = self.ctx.udwf(name)
+        return wrapper
+
+    def udfs(self) -> list[str]:
+        """Return the sorted names of all registered scalar UDFs."""
+        return self.ctx.udfs()
+
+    def udafs(self) -> list[str]:
+        """Return the sorted names of all registered aggregate UDFs."""
+        return self.ctx.udafs()
+
+    def udwfs(self) -> list[str]:
+        """Return the sorted names of all registered window UDFs."""
+        return self.ctx.udwfs()
+
     def catalog(self, name: str = "datafusion") -> Catalog:
         """Retrieve a catalog by name."""
         return Catalog(self.ctx.catalog(name))

--- a/python/datafusion/context.py
+++ b/python/datafusion/context.py
@@ -1320,11 +1320,11 @@ class SessionContext:
     def udf(self, name: str) -> ScalarUDF:
         """Look up a registered scalar UDF by name.
 
-        Returns the same :py:class:`~datafusion.user_defined.ScalarUDF`
-        wrapper that :py:meth:`register_udf` accepts, so it can be invoked
-        as an expression in the DataFrame API or re-registered into a
-        different :py:class:`SessionContext`. Built-in scalar functions
-        from the session's function registry are also looked up.
+        Returns the same ``ScalarUDF`` wrapper that :py:meth:`register_udf`
+        accepts, so it can be invoked as an expression in the DataFrame API
+        or re-registered into a different :py:class:`SessionContext`.
+        Built-in scalar functions from the session's function registry are
+        also looked up.
 
         Args:
             name: Name of the registered scalar UDF.
@@ -1366,11 +1366,10 @@ class SessionContext:
     def udaf(self, name: str) -> AggregateUDF:
         """Look up a registered aggregate UDF by name.
 
-        Returns the same :py:class:`~datafusion.user_defined.AggregateUDF`
-        wrapper that :py:meth:`register_udaf` accepts. Built-in aggregate
-        functions such as ``sum`` or ``avg`` are also discoverable through
-        this lookup. See :py:meth:`udf` for a worked late-binding example;
-        the pattern is identical for aggregates.
+        Returns the same ``AggregateUDF`` wrapper that :py:meth:`register_udaf`
+        accepts. Built-in aggregate functions such as ``sum`` or ``avg`` are
+        also discoverable through this lookup. See :py:meth:`udf` for a worked
+        late-binding example; the pattern is identical for aggregates.
 
         Args:
             name: Name of the registered aggregate UDF.
@@ -1397,11 +1396,11 @@ class SessionContext:
     def udwf(self, name: str) -> WindowUDF:
         """Look up a registered window UDF by name.
 
-        Returns the same :py:class:`~datafusion.user_defined.WindowUDF`
-        wrapper that :py:meth:`register_udwf` accepts. Built-in window
-        functions such as ``row_number`` or ``rank`` are also discoverable
-        through this lookup. See :py:meth:`udf` for a worked late-binding
-        example; the pattern is identical for window functions.
+        Returns the same ``WindowUDF`` wrapper that :py:meth:`register_udwf`
+        accepts. Built-in window functions such as ``row_number`` or ``rank``
+        are also discoverable through this lookup. See :py:meth:`udf` for a
+        worked late-binding example; the pattern is identical for window
+        functions.
 
         Args:
             name: Name of the registered window UDF.

--- a/python/datafusion/context.py
+++ b/python/datafusion/context.py
@@ -1313,11 +1313,44 @@ class SessionContext:
     def udf(self, name: str) -> ScalarUDF:
         """Look up a registered scalar UDF by name.
 
+        Returns the same :py:class:`~datafusion.user_defined.ScalarUDF`
+        wrapper that :py:meth:`register_udf` accepts, so it can be invoked
+        as an expression in the DataFrame API or re-registered into a
+        different :py:class:`SessionContext`. Built-in scalar functions
+        from the session's function registry are also looked up.
+
         Args:
             name: Name of the registered scalar UDF.
 
         Raises:
             Exception: If no scalar UDF is registered under ``name``.
+
+        Examples:
+            Register a UDF, then look it up by name and use it in the
+            DataFrame API:
+
+            >>> ctx = dfn.SessionContext()
+            >>> nullcheck = dfn.udf(
+            ...     lambda x: x.is_null(),
+            ...     [pa.int64()],
+            ...     pa.bool_(),
+            ...     volatility="immutable",
+            ...     name="nullcheck",
+            ... )
+            >>> ctx.register_udf(nullcheck)
+            >>> fn = ctx.udf("nullcheck")
+            >>> df = ctx.from_pydict({"a": [1, None, 3]})
+            >>> df.select(fn(col("a")).alias("is_null")).to_pydict()
+            {'is_null': [False, True, False]}
+
+            Late-binding: the function name can come from configuration
+            rather than an imported symbol, which is useful when the set
+            of UDFs is plugin-driven or chosen at runtime:
+
+            >>> config = {"null_check": "nullcheck"}
+            >>> fn = ctx.udf(config["null_check"])
+            >>> df.select(fn(col("a")).alias("is_null")).to_pydict()
+            {'is_null': [False, True, False]}
         """
         from datafusion.user_defined import ScalarUDF as _ScalarUDF  # noqa: PLC0415
 
@@ -1328,11 +1361,27 @@ class SessionContext:
     def udaf(self, name: str) -> AggregateUDF:
         """Look up a registered aggregate UDF by name.
 
+        Returns the same :py:class:`~datafusion.user_defined.AggregateUDF`
+        wrapper that :py:meth:`register_udaf` accepts. Built-in aggregate
+        functions such as ``sum`` or ``avg`` are also discoverable through
+        this lookup. See :py:meth:`udf` for a worked late-binding example;
+        the pattern is identical for aggregates.
+
         Args:
             name: Name of the registered aggregate UDF.
 
         Raises:
             Exception: If no aggregate UDF is registered under ``name``.
+
+        Examples:
+            Look up a built-in aggregate by name and use it in
+            :py:meth:`~datafusion.DataFrame.aggregate`:
+
+            >>> ctx = dfn.SessionContext()
+            >>> sum_fn = ctx.udaf("sum")
+            >>> df = ctx.from_pydict({"a": [1, 2, 3]})
+            >>> df.aggregate([], [sum_fn(col("a")).alias("total")]).to_pydict()
+            {'total': [6]}
         """
         from datafusion.user_defined import (  # noqa: PLC0415
             AggregateUDF as _AggregateUDF,
@@ -1345,11 +1394,27 @@ class SessionContext:
     def udwf(self, name: str) -> WindowUDF:
         """Look up a registered window UDF by name.
 
+        Returns the same :py:class:`~datafusion.user_defined.WindowUDF`
+        wrapper that :py:meth:`register_udwf` accepts. Built-in window
+        functions such as ``row_number`` or ``rank`` are also discoverable
+        through this lookup. See :py:meth:`udf` for a worked late-binding
+        example; the pattern is identical for window functions.
+
         Args:
             name: Name of the registered window UDF.
 
         Raises:
             Exception: If no window UDF is registered under ``name``.
+
+        Examples:
+            Look up a built-in window function by name and use it in
+            ``select``:
+
+            >>> ctx = dfn.SessionContext()
+            >>> rn = ctx.udwf("row_number")
+            >>> df = ctx.from_pydict({"a": [10, 20, 30]})
+            >>> df.select(col("a"), rn().alias("rn")).to_pydict()
+            {'a': [10, 20, 30], 'rn': [1, 2, 3]}
         """
         from datafusion.user_defined import WindowUDF as _WindowUDF  # noqa: PLC0415
 
@@ -1358,15 +1423,37 @@ class SessionContext:
         return wrapper
 
     def udfs(self) -> list[str]:
-        """Return the sorted names of all registered scalar UDFs."""
+        """Return the sorted names of all registered scalar UDFs.
+
+        Includes both user-registered and built-in scalar functions. Pair
+        with :py:meth:`udf` to drive discovery, validation, or config-based
+        dispatch.
+
+        Examples:
+            >>> ctx = dfn.SessionContext()
+            >>> "abs" in ctx.udfs()
+            True
+        """
         return self.ctx.udfs()
 
     def udafs(self) -> list[str]:
-        """Return the sorted names of all registered aggregate UDFs."""
+        """Return the sorted names of all registered aggregate UDFs.
+
+        Examples:
+            >>> ctx = dfn.SessionContext()
+            >>> "sum" in ctx.udafs()
+            True
+        """
         return self.ctx.udafs()
 
     def udwfs(self) -> list[str]:
-        """Return the sorted names of all registered window UDFs."""
+        """Return the sorted names of all registered window UDFs.
+
+        Examples:
+            >>> ctx = dfn.SessionContext()
+            >>> "row_number" in ctx.udwfs()
+            True
+        """
         return self.ctx.udwfs()
 
     def catalog(self, name: str = "datafusion") -> Catalog:

--- a/python/datafusion/context.py
+++ b/python/datafusion/context.py
@@ -1323,7 +1323,7 @@ class SessionContext:
             name: Name of the registered scalar UDF.
 
         Raises:
-            Exception: If no scalar UDF is registered under ``name``.
+            KeyError: If no scalar UDF is registered under ``name``.
 
         Examples:
             Register a UDF, then look it up by name and use it in the
@@ -1371,7 +1371,7 @@ class SessionContext:
             name: Name of the registered aggregate UDF.
 
         Raises:
-            Exception: If no aggregate UDF is registered under ``name``.
+            KeyError: If no aggregate UDF is registered under ``name``.
 
         Examples:
             Look up a built-in aggregate by name and use it in
@@ -1404,7 +1404,7 @@ class SessionContext:
             name: Name of the registered window UDF.
 
         Raises:
-            Exception: If no window UDF is registered under ``name``.
+            KeyError: If no window UDF is registered under ``name``.
 
         Examples:
             Look up a built-in window function by name and use it in

--- a/python/datafusion/context.py
+++ b/python/datafusion/context.py
@@ -1354,9 +1354,7 @@ class SessionContext:
         """
         from datafusion.user_defined import ScalarUDF as _ScalarUDF  # noqa: PLC0415
 
-        wrapper = _ScalarUDF.__new__(_ScalarUDF)
-        wrapper._udf = self.ctx.udf(name)
-        return wrapper
+        return _ScalarUDF._from_internal(self.ctx.udf(name))
 
     def udaf(self, name: str) -> AggregateUDF:
         """Look up a registered aggregate UDF by name.
@@ -1387,9 +1385,7 @@ class SessionContext:
             AggregateUDF as _AggregateUDF,
         )
 
-        wrapper = _AggregateUDF.__new__(_AggregateUDF)
-        wrapper._udaf = self.ctx.udaf(name)
-        return wrapper
+        return _AggregateUDF._from_internal(self.ctx.udaf(name))
 
     def udwf(self, name: str) -> WindowUDF:
         """Look up a registered window UDF by name.
@@ -1418,9 +1414,7 @@ class SessionContext:
         """
         from datafusion.user_defined import WindowUDF as _WindowUDF  # noqa: PLC0415
 
-        wrapper = _WindowUDF.__new__(_WindowUDF)
-        wrapper._udwf = self.ctx.udwf(name)
-        return wrapper
+        return _WindowUDF._from_internal(self.ctx.udwf(name))
 
     def udfs(self) -> list[str]:
         """Return the sorted names of all registered scalar UDFs.

--- a/python/datafusion/functions.py
+++ b/python/datafusion/functions.py
@@ -2749,12 +2749,10 @@ def get_field(expr: Expr, *names: Expr | str) -> Expr:
         >>> df = ctx.from_pydict({"a": [1], "b": [2]})
         >>> df = df.with_column(
         ...     "s",
-        ...     dfn.functions.named_struct(
-        ...         [("x", dfn.col("a")), ("y", dfn.col("b"))]
-        ...     ),
+        ...     F.named_struct([("x", dfn.col("a")), ("y", dfn.col("b"))]),
         ... )
         >>> result = df.select(
-        ...     dfn.functions.get_field(dfn.col("s"), "x").alias("x_val")
+        ...     F.get_field(dfn.col("s"), "x").alias("x_val")
         ... )
         >>> result.collect_column("x_val")[0].as_py()
         1
@@ -2771,12 +2769,10 @@ def get_field(expr: Expr, *names: Expr | str) -> Expr:
 
         >>> df = df.with_column(
         ...     "outer",
-        ...     dfn.functions.named_struct([("inner", dfn.col("s"))]),
+        ...     F.named_struct([("inner", dfn.col("s"))]),
         ... )
         >>> result = df.select(
-        ...     dfn.functions.get_field(
-        ...         dfn.col("outer"), "inner", "x"
-        ...     ).alias("x_val")
+        ...     F.get_field(dfn.col("outer"), "inner", "x").alias("x_val")
         ... )
         >>> result.collect_column("x_val")[0].as_py()
         1

--- a/python/datafusion/functions.py
+++ b/python/datafusion/functions.py
@@ -2727,14 +2727,24 @@ def arrow_metadata(expr: Expr, key: Expr | str | None = None) -> Expr:
     return Expr(f.arrow_metadata(expr.expr, key.expr))
 
 
-def get_field(expr: Expr, name: Expr | str) -> Expr:
-    """Extracts a field from a struct or map by name.
+def get_field(expr: Expr, *names: Expr | str) -> Expr:
+    """Extracts a (possibly nested) field from a struct or map by name.
 
-    When the field name is a static string, the bracket operator
-    ``expr["field"]`` is a convenient shorthand. Use ``get_field``
-    when the field name is a dynamic expression.
+    Pass one name for a single-level lookup, or several names to walk a path
+    of nested struct/map fields in a single ``get_field`` call. For a single
+    static-string name, ``expr["field"]`` is a convenient shorthand; use
+    ``get_field`` when the field name is a dynamic
+    :py:class:`~datafusion.expr.Expr` or when traversing multiple levels at
+    once.
+
+    Args:
+        expr: The struct or map expression to read from.
+        *names: One or more field names (``str``) or expressions
+            (:py:class:`~datafusion.expr.Expr`).
 
     Examples:
+        Single-level lookup:
+
         >>> ctx = dfn.SessionContext()
         >>> df = ctx.from_pydict({"a": [1], "b": [2]})
         >>> df = df.with_column(
@@ -2756,10 +2766,26 @@ def get_field(expr: Expr, name: Expr | str) -> Expr:
         ... )
         >>> result.collect_column("x_val")[0].as_py()
         1
+
+        Multi-level lookup:
+
+        >>> df = df.with_column(
+        ...     "outer",
+        ...     dfn.functions.named_struct([("inner", dfn.col("s"))]),
+        ... )
+        >>> result = df.select(
+        ...     dfn.functions.get_field(
+        ...         dfn.col("outer"), "inner", "x"
+        ...     ).alias("x_val")
+        ... )
+        >>> result.collect_column("x_val")[0].as_py()
+        1
     """
-    if isinstance(name, str):
-        name = Expr.string_literal(name)
-    return Expr(f.get_field(expr.expr, name.expr))
+    if not names:
+        msg = "get_field requires at least one field name"
+        raise ValueError(msg)
+    resolved = [Expr.string_literal(n) if isinstance(n, str) else n for n in names]
+    return Expr(f.get_field(expr.expr, [n.expr for n in resolved]))
 
 
 def union_extract(union_expr: Expr, field_name: Expr | str) -> Expr:

--- a/python/datafusion/user_defined.py
+++ b/python/datafusion/user_defined.py
@@ -113,6 +113,18 @@ def _is_pycapsule(value: object) -> TypeGuard[_PyCapsule]:
     return value.__class__.__name__ == "PyCapsule"
 
 
+class LogicalExtensionCodecExportable(Protocol):
+    """Type hint for objects exposing ``__datafusion_logical_extension_codec__``."""
+
+    def __datafusion_logical_extension_codec__(self) -> object: ...  # noqa: D105
+
+
+class PhysicalExtensionCodecExportable(Protocol):
+    """Type hint for objects exposing ``__datafusion_physical_extension_codec__``."""
+
+    def __datafusion_physical_extension_codec__(self) -> object: ...  # noqa: D105
+
+
 class ScalarUDF:
     """Class for performing scalar user-defined functions (UDF).
 

--- a/python/datafusion/user_defined.py
+++ b/python/datafusion/user_defined.py
@@ -153,6 +153,18 @@ class ScalarUDF:
             name, func, input_fields, return_field, str(volatility)
         )
 
+    @classmethod
+    def _from_internal(cls, internal: df_internal.ScalarUDF) -> ScalarUDF:
+        """Wrap an already-constructed internal ``ScalarUDF`` handle.
+
+        Used by :py:meth:`SessionContext.udf` to surface a function looked
+        up from the session's function registry without re-running
+        :py:meth:`__init__`.
+        """
+        wrapper = cls.__new__(cls)
+        wrapper._udf = internal
+        return wrapper
+
     @property
     def name(self) -> str:
         """Return the registered name of this UDF.
@@ -452,6 +464,18 @@ class AggregateUDF:
             state_type,
             str(volatility),
         )
+
+    @classmethod
+    def _from_internal(cls, internal: df_internal.AggregateUDF) -> AggregateUDF:
+        """Wrap an already-constructed internal ``AggregateUDF`` handle.
+
+        Used by :py:meth:`SessionContext.udaf` to surface a function looked
+        up from the session's function registry without re-running
+        :py:meth:`__init__`.
+        """
+        wrapper = cls.__new__(cls)
+        wrapper._udaf = internal
+        return wrapper
 
     @property
     def name(self) -> str:
@@ -872,6 +896,18 @@ class WindowUDF:
         self._udwf = df_internal.WindowUDF(
             name, func, input_types, return_type, str(volatility)
         )
+
+    @classmethod
+    def _from_internal(cls, internal: df_internal.WindowUDF) -> WindowUDF:
+        """Wrap an already-constructed internal ``WindowUDF`` handle.
+
+        Used by :py:meth:`SessionContext.udwf` to surface a function looked
+        up from the session's function registry without re-running
+        :py:meth:`__init__`.
+        """
+        wrapper = cls.__new__(cls)
+        wrapper._udwf = internal
+        return wrapper
 
     @property
     def name(self) -> str:

--- a/python/tests/test_context.py
+++ b/python/tests/test_context.py
@@ -920,6 +920,17 @@ def test_read_batches_concatenates(ctx):
     assert df.to_pydict() == {"a": [1, 2, 3, 4]}
 
 
+def test_read_batches_accepts_iterable(ctx):
+    b1 = pa.RecordBatch.from_pydict({"a": [1, 2]})
+    b2 = pa.RecordBatch.from_pydict({"a": [3, 4]})
+    # Generator: ensures non-list iterables are materialized before FFI.
+    df = ctx.read_batches(b for b in (b1, b2))
+    assert df.to_pydict() == {"a": [1, 2, 3, 4]}
+    # Tuple: same.
+    df = ctx.read_batches((b1, b2))
+    assert df.to_pydict() == {"a": [1, 2, 3, 4]}
+
+
 def test_create_sql_options():
     SQLOptions()
 

--- a/python/tests/test_context.py
+++ b/python/tests/test_context.py
@@ -905,6 +905,21 @@ def test_register_batch_empty(ctx):
     assert result[0].num_rows == 0
 
 
+def test_read_batch_returns_dataframe(ctx):
+    batch = pa.RecordBatch.from_pydict({"a": [1, 2, 3], "b": [4, 5, 6]})
+    df = ctx.read_batch(batch)
+    assert df.to_pydict() == {"a": [1, 2, 3], "b": [4, 5, 6]}
+    # read_batch should not register a named table.
+    assert ctx.catalog().schema().names() == set()
+
+
+def test_read_batches_concatenates(ctx):
+    b1 = pa.RecordBatch.from_pydict({"a": [1, 2]})
+    b2 = pa.RecordBatch.from_pydict({"a": [3, 4]})
+    df = ctx.read_batches([b1, b2])
+    assert df.to_pydict() == {"a": [1, 2, 3, 4]}
+
+
 def test_create_sql_options():
     SQLOptions()
 

--- a/python/tests/test_dataframe.py
+++ b/python/tests/test_dataframe.py
@@ -1704,8 +1704,12 @@ def test_repr_rows_backward_compatibility(clean_formatter_state):
     assert formatter.max_rows == 15
     assert formatter.repr_rows == 15
 
-    # Should fail when conflicting with max_rows
-    with pytest.raises(ValueError, match="Cannot specify both repr_rows and max_rows"):
+    # Should fail when conflicting with max_rows. The deprecation warning still
+    # fires before the ValueError, so assert both.
+    with (
+        pytest.raises(ValueError, match="Cannot specify both repr_rows and max_rows"),
+        pytest.warns(DeprecationWarning, match="repr_rows parameter is deprecated"),
+    ):
         DataFrameHtmlFormatter(repr_rows=5, max_rows=10)
 
     # Setting repr_rows via property should warn

--- a/python/tests/test_functions.py
+++ b/python/tests/test_functions.py
@@ -1957,6 +1957,37 @@ def test_get_field(df):
     assert result.column(1) == pa.array([4, 5, 6])
 
 
+def test_get_field_path(df):
+    df = df.with_column(
+        "outer",
+        f.named_struct(
+            [
+                (
+                    "inner",
+                    f.named_struct(
+                        [
+                            ("x", column("a")),
+                            ("y", column("b")),
+                        ]
+                    ),
+                ),
+            ]
+        ),
+    )
+    result = df.select(
+        f.get_field(column("outer"), "inner", "x").alias("x_val"),
+        f.get_field(column("outer"), "inner", "y").alias("y_val"),
+    ).collect()[0]
+
+    assert result.column(0) == pa.array(["Hello", "World", "!"], type=pa.string_view())
+    assert result.column(1) == pa.array([4, 5, 6])
+
+
+def test_get_field_requires_a_name():
+    with pytest.raises(ValueError, match="at least one field name"):
+        f.get_field(column("s"))
+
+
 def test_arrow_metadata():
     ctx = SessionContext()
     field = pa.field("val", pa.int64(), metadata={"key1": "value1", "key2": "value2"})

--- a/python/tests/test_sql.py
+++ b/python/tests/test_sql.py
@@ -450,13 +450,9 @@ _null_mask = np.array([False, True, False])
             pa.array([b"1111", b"2222", b"3333"], pa.binary(4), _null_mask),
             id="binary4",
         ),
-        # `timestamp[s]` does not roundtrip for pyarrow.parquet: https://github.com/apache/arrow/issues/41382
         pytest.param(
             helpers.data_datetime("s"),
             id="datetime_s",
-            marks=pytest.mark.xfail(
-                reason="pyarrow.parquet does not support timestamp[s] roundtrips"
-            ),
         ),
         pytest.param(
             helpers.data_datetime("ms"),
@@ -483,6 +479,16 @@ def test_simple_select(ctx, tmp_path, arr):
 
     batches = ctx.sql("SELECT a AS tt FROM t").collect()
     result = batches[0].column(0)
+
+    # pyarrow.parquet promotes timestamp[s] to timestamp[ms] on write
+    # (https://github.com/apache/arrow/issues/41382). Compensate so the
+    # comparison checks DataFusion reads what Arrow actually stored.
+    if (
+        isinstance(arr, pa.Array)
+        and pa.types.is_timestamp(arr.type)
+        and arr.type.unit == "s"
+    ):
+        arr = arr.cast(pa.timestamp("ms"))
 
     # In DF 43.0.0 we now default to having BinaryView and StringView
     # so the array that is saved to the parquet is slightly different

--- a/python/tests/test_udf.py
+++ b/python/tests/test_udf.py
@@ -76,6 +76,27 @@ def test_register_udf(ctx, df) -> None:
     assert result == pa.array([False, False, True])
 
 
+def test_udf_lookup(ctx, df) -> None:
+    is_null = udf(
+        lambda x: x.is_null(),
+        [pa.float64()],
+        pa.bool_(),
+        volatility="immutable",
+        name="lookup_is_null",
+    )
+    ctx.register_udf(is_null)
+
+    assert "lookup_is_null" in ctx.udfs()
+
+    looked_up = ctx.udf("lookup_is_null")
+    df_result = df.select(looked_up(column("b")))
+    result = df_result.collect()[0].column(0)
+    assert result == pa.array([False, False, True])
+
+    with pytest.raises(Exception, match="no UDF named"):
+        ctx.udf("does_not_exist")
+
+
 class OverThresholdUDF:
     def __init__(self, threshold: int = 0) -> None:
         self.threshold = threshold

--- a/python/tests/test_udf.py
+++ b/python/tests/test_udf.py
@@ -97,6 +97,56 @@ def test_udf_lookup(ctx, df) -> None:
         ctx.udf("does_not_exist")
 
 
+def test_udf_late_binding_dispatch(ctx, df) -> None:
+    """Resolve a UDF chosen by configuration string, then invoke it."""
+    late_is_null = udf(
+        lambda x: x.is_null(),
+        [pa.int64()],
+        pa.bool_(),
+        volatility="immutable",
+        name="late_is_null",
+    )
+    late_is_not_null = udf(
+        lambda x: pc.invert(x.is_null()),
+        [pa.int64()],
+        pa.bool_(),
+        volatility="immutable",
+        name="late_is_not_null",
+    )
+
+    ctx.register_udf(late_is_null)
+    ctx.register_udf(late_is_not_null)
+
+    # Pretend this came from a config file / API request — only a string.
+    runtime_config = {"check_fn": "late_is_not_null"}
+
+    assert runtime_config["check_fn"] in ctx.udfs()
+
+    fn = ctx.udf(runtime_config["check_fn"])
+    result = df.select(fn(column("b")).alias("ok")).collect()[0].column(0)
+    assert result == pa.array([True, True, False])
+
+
+def test_udaf_lookup_builtin(ctx, df) -> None:
+    assert "sum" in ctx.udafs()
+    sum_fn = ctx.udaf("sum")
+    result = df.aggregate([], [sum_fn(column("a")).alias("total")]).collect()
+    assert result[0].column(0).to_pylist() == [6]
+
+    with pytest.raises(Exception, match="no UDAF named"):
+        ctx.udaf("does_not_exist")
+
+
+def test_udwf_lookup_builtin(ctx, df) -> None:
+    assert "row_number" in ctx.udwfs()
+    rn = ctx.udwf("row_number")
+    result = df.select(column("a"), rn().alias("rn")).collect()
+    assert result[0].column(1).to_pylist() == [1, 2, 3]
+
+    with pytest.raises(Exception, match="no UDWF named"):
+        ctx.udwf("does_not_exist")
+
+
 class OverThresholdUDF:
     def __init__(self, threshold: int = 0) -> None:
         self.threshold = threshold

--- a/python/tests/test_udf.py
+++ b/python/tests/test_udf.py
@@ -93,7 +93,7 @@ def test_udf_lookup(ctx, df) -> None:
     result = df_result.collect()[0].column(0)
     assert result == pa.array([False, False, True])
 
-    with pytest.raises(Exception, match="no UDF named"):
+    with pytest.raises(KeyError, match="no UDF named"):
         ctx.udf("does_not_exist")
 
 
@@ -133,7 +133,7 @@ def test_udaf_lookup_builtin(ctx, df) -> None:
     result = df.aggregate([], [sum_fn(column("a")).alias("total")]).collect()
     assert result[0].column(0).to_pylist() == [6]
 
-    with pytest.raises(Exception, match="no UDAF named"):
+    with pytest.raises(KeyError, match="no UDAF named"):
         ctx.udaf("does_not_exist")
 
 
@@ -143,7 +143,7 @@ def test_udwf_lookup_builtin(ctx, df) -> None:
     result = df.select(column("a"), rn().alias("rn")).collect()
     assert result[0].column(1).to_pylist() == [1, 2, 3]
 
-    with pytest.raises(Exception, match="no UDWF named"):
+    with pytest.raises(KeyError, match="no UDWF named"):
         ctx.udwf("does_not_exist")
 
 


### PR DESCRIPTION
# Which issue does this PR close?

No single issue — this is wave 1 of follow-up work after the DataFusion 54 upgrade (#1532). Each commit is self-contained and can be reviewed independently.

# Rationale for this change

DataFusion 54 introduced or deprecated several pieces of upstream API surface that the Python bindings had not yet caught up with. This PR closes the highest-value gaps.

# What changes are included in this PR?

- Add `LogicalExtensionCodecExportable` / `PhysicalExtensionCodecExportable` to make hinting signatures more understandable
- Expose `get_field_path` but instead fold it into `get_field` to be more pythonic
- expose `SessionContext.read_batches` / `read_batch`
- expose UDF lookup helpers
- bump pre-commit so it stops failing CI checks
- Minor changes to unit tests so deprecation warning doesn't show and we no longer have xfail test

# Are there any user-facing changes?

Yes, but they are all additions. No breaking changes to existing public APIs.