### PR TITLE
fix: Skip `fork` and `forkserver` on `win32`

### DIFF
--- a/python/tests/test_pickle_multiprocessing.py
+++ b/python/tests/test_pickle_multiprocessing.py
@@ -84,11 +84,17 @@ START_METHODS = [
     pytest.param(
         "fork",
         marks=pytest.mark.skipif(
-            sys.platform == "darwin",
-            reason="fork start method is unsafe with PyArrow/tokio on macOS",
+            sys.platform in ("darwin", "win32"),
+            reason="fork start method is not supported on Windows and unsafe with PyArrow/tokio on macOS",
         ),
     ),
-    "forkserver",
+    pytest.param(
+        "forkserver",
+        marks=pytest.mark.skipif(
+            sys.platform == "win32",
+            reason="forkserver start method is not supported on Windows",
+        ),
+    ),
     "spawn",
 ]
 

--- a/python/tests/test_pickle_multiprocessing.py
+++ b/python/tests/test_pickle_multiprocessing.py
@@ -85,7 +85,8 @@ START_METHODS = [
         "fork",
         marks=pytest.mark.skipif(
             sys.platform in ("darwin", "win32"),
-            reason="fork start method is not supported on Windows and unsafe with PyArrow/tokio on macOS",
+            reason="fork start method is not supported on Windows "
+            "and unsafe with PyArrow/tokio on macOS",
         ),
     ),
     pytest.param(


### PR DESCRIPTION
# Which issue does this PR close?

N/A.

 # Rationale for this change

Only `spawn` is supported on Windows, so skip `fork` and `forkserver` in `test_pickle_multiprocessing`.

# What changes are included in this PR?

- Updated `test_pickle_multiprocessing` tests.

# Are there any user-facing changes?

No.