### PR TITLE
feat: expose arrow_field, arrow_try_cast, cast_to_type, with_metadata

### DIFF
--- a/crates/core/src/expr.rs
+++ b/crates/core/src/expr.rs
@@ -358,6 +358,11 @@ impl PyExpr {
         expr.into()
     }
 
+    pub fn try_cast(&self, to: PyArrowType<DataType>) -> PyExpr {
+        let expr = Expr::TryCast(TryCast::new(Box::new(self.expr.clone()), to.0));
+        expr.into()
+    }
+
     #[pyo3(signature = (low, high, negated=false))]
     pub fn between(&self, low: PyExpr, high: PyExpr, negated: bool) -> PyExpr {
         let expr = Expr::Between(Between::new(

--- a/crates/core/src/functions.rs
+++ b/crates/core/src/functions.rs
@@ -607,7 +607,12 @@ expr_fn_vec!(named_struct);
 expr_fn!(from_unixtime, unixtime);
 expr_fn!(arrow_typeof, arg_1);
 expr_fn!(arrow_cast, arg_1 datatype);
+expr_fn!(arrow_try_cast, arg_1 datatype);
+expr_fn!(arrow_field, arg_1);
+expr_fn!(cast_to_type, arg_1 reference);
+expr_fn!(try_cast_to_type, arg_1 reference);
 expr_fn_vec!(arrow_metadata);
+expr_fn_vec!(with_metadata);
 expr_fn!(union_tag, arg1);
 expr_fn!(random);
 
@@ -962,7 +967,12 @@ pub(crate) fn init_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(array_agg))?;
     m.add_wrapped(wrap_pyfunction!(arrow_typeof))?;
     m.add_wrapped(wrap_pyfunction!(arrow_cast))?;
+    m.add_wrapped(wrap_pyfunction!(arrow_try_cast))?;
+    m.add_wrapped(wrap_pyfunction!(arrow_field))?;
+    m.add_wrapped(wrap_pyfunction!(cast_to_type))?;
+    m.add_wrapped(wrap_pyfunction!(try_cast_to_type))?;
     m.add_wrapped(wrap_pyfunction!(arrow_metadata))?;
+    m.add_wrapped(wrap_pyfunction!(with_metadata))?;
     m.add_wrapped(wrap_pyfunction!(ascii))?;
     m.add_wrapped(wrap_pyfunction!(asin))?;
     m.add_wrapped(wrap_pyfunction!(asinh))?;

--- a/crates/core/src/functions.rs
+++ b/crates/core/src/functions.rs
@@ -609,15 +609,8 @@ expr_fn!(arrow_typeof, arg_1);
 expr_fn!(arrow_cast, arg_1 datatype);
 expr_fn!(arrow_try_cast, arg_1 datatype);
 expr_fn!(arrow_field, arg_1);
-#[pyfunction]
-#[pyo3(signature = (arg_1, reference, *, try_cast = false))]
-fn cast_to_type(arg_1: PyExpr, reference: PyExpr, try_cast: bool) -> PyExpr {
-    if try_cast {
-        functions::expr_fn::try_cast_to_type(arg_1.into(), reference.into()).into()
-    } else {
-        functions::expr_fn::cast_to_type(arg_1.into(), reference.into()).into()
-    }
-}
+expr_fn!(cast_to_type, arg_1 reference);
+expr_fn!(try_cast_to_type, arg_1 reference);
 expr_fn_vec!(arrow_metadata);
 expr_fn_vec!(with_metadata);
 expr_fn!(union_tag, arg1);
@@ -977,6 +970,7 @@ pub(crate) fn init_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(arrow_try_cast))?;
     m.add_wrapped(wrap_pyfunction!(arrow_field))?;
     m.add_wrapped(wrap_pyfunction!(cast_to_type))?;
+    m.add_wrapped(wrap_pyfunction!(try_cast_to_type))?;
     m.add_wrapped(wrap_pyfunction!(arrow_metadata))?;
     m.add_wrapped(wrap_pyfunction!(with_metadata))?;
     m.add_wrapped(wrap_pyfunction!(ascii))?;

--- a/crates/core/src/functions.rs
+++ b/crates/core/src/functions.rs
@@ -609,8 +609,15 @@ expr_fn!(arrow_typeof, arg_1);
 expr_fn!(arrow_cast, arg_1 datatype);
 expr_fn!(arrow_try_cast, arg_1 datatype);
 expr_fn!(arrow_field, arg_1);
-expr_fn!(cast_to_type, arg_1 reference);
-expr_fn!(try_cast_to_type, arg_1 reference);
+#[pyfunction]
+#[pyo3(signature = (arg_1, reference, *, try_cast = false))]
+fn cast_to_type(arg_1: PyExpr, reference: PyExpr, try_cast: bool) -> PyExpr {
+    if try_cast {
+        functions::expr_fn::try_cast_to_type(arg_1.into(), reference.into()).into()
+    } else {
+        functions::expr_fn::cast_to_type(arg_1.into(), reference.into()).into()
+    }
+}
 expr_fn_vec!(arrow_metadata);
 expr_fn_vec!(with_metadata);
 expr_fn!(union_tag, arg1);
@@ -970,7 +977,6 @@ pub(crate) fn init_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(arrow_try_cast))?;
     m.add_wrapped(wrap_pyfunction!(arrow_field))?;
     m.add_wrapped(wrap_pyfunction!(cast_to_type))?;
-    m.add_wrapped(wrap_pyfunction!(try_cast_to_type))?;
     m.add_wrapped(wrap_pyfunction!(arrow_metadata))?;
     m.add_wrapped(wrap_pyfunction!(with_metadata))?;
     m.add_wrapped(wrap_pyfunction!(ascii))?;

--- a/python/datafusion/expr.py
+++ b/python/datafusion/expr.py
@@ -894,6 +894,28 @@ class Expr:  # noqa: PLW1641
 
         return Expr(self.expr.cast(to))
 
+    def try_cast(self, to: pa.DataType[Any] | type) -> Expr:
+        """Cast to a new data type, returning NULL on failure.
+
+        Like :py:meth:`cast` but produces NULL instead of erroring when the
+        cast cannot be performed for a given row.
+
+        Examples:
+            >>> ctx = dfn.SessionContext()
+            >>> df = ctx.from_pydict({"a": ["oops"]})
+            >>> result = df.select(col("a").try_cast(pa.float64()).alias("c"))
+            >>> result.collect_column("c")[0].as_py() is None
+            True
+        """
+        if not isinstance(to, pa.DataType):
+            try:
+                to = self._to_pyarrow_types[to]
+            except KeyError as err:
+                error_msg = "Expected instance of pyarrow.DataType or builtins.type"
+                raise TypeError(error_msg) from err
+
+        return Expr(self.expr.try_cast(to))
+
     def between(self, low: Any, high: Any, negated: bool = False) -> Expr:
         """Returns ``True`` if this expression is between a given range.
 

--- a/python/datafusion/functions.py
+++ b/python/datafusion/functions.py
@@ -120,7 +120,9 @@ __all__ = [
     "arrays_overlap",
     "arrays_zip",
     "arrow_cast",
+    "arrow_field",
     "arrow_metadata",
+    "arrow_try_cast",
     "arrow_typeof",
     "ascii",
     "asin",
@@ -138,6 +140,7 @@ __all__ = [
     "btrim",
     "cardinality",
     "case",
+    "cast_to_type",
     "cbrt",
     "ceil",
     "char_length",
@@ -368,6 +371,7 @@ __all__ = [
     "var_sample",
     "version",
     "when",
+    "with_metadata",
 ]
 
 
@@ -2930,6 +2934,82 @@ def arrow_cast(expr: Expr, data_type: Expr | str | pa.DataType) -> Expr:
     return Expr(f.arrow_cast(expr.expr, data_type.expr))
 
 
+def arrow_try_cast(expr: Expr, data_type: Expr | str) -> Expr:
+    """Casts an expression to a specified data type, returning NULL on failure.
+
+    Like :py:func:`arrow_cast` but produces NULL instead of erroring when the
+    cast cannot be performed. The ``data_type`` may be a string in DataFusion
+    type syntax (for example ``"Float64"``) or an ``Expr`` of string type.
+
+    Examples:
+        >>> ctx = dfn.SessionContext()
+        >>> df = ctx.from_pydict({"a": ["oops"]})
+        >>> result = df.select(
+        ...     dfn.functions.arrow_try_cast(dfn.col("a"), "Float64").alias("c")
+        ... )
+        >>> result.collect_column("c")[0].as_py() is None
+        True
+    """
+    if isinstance(data_type, str):
+        data_type = Expr.string_literal(data_type)
+    return Expr(f.arrow_try_cast(expr.expr, data_type.expr))
+
+
+def arrow_field(expr: Expr) -> Expr:
+    """Returns the Arrow field information of an expression as a struct.
+
+    The returned struct contains the field's name, data type, nullability,
+    and metadata.
+
+    Examples:
+        >>> field = pa.field("val", pa.int64(), metadata={"k": "v"})
+        >>> schema = pa.schema([field])
+        >>> batch = pa.RecordBatch.from_arrays([pa.array([1])], schema=schema)
+        >>> ctx = dfn.SessionContext()
+        >>> df = ctx.create_dataframe([[batch]])
+        >>> result = df.select(
+        ...     dfn.functions.arrow_field(dfn.col("val")).alias("f")
+        ... )
+        >>> result.collect_column("f")[0].as_py()["name"]
+        'val'
+    """
+    return Expr(f.arrow_field(expr.expr))
+
+
+def cast_to_type(value: Expr, type_ref: Expr, *, try_cast: bool = False) -> Expr:
+    """Casts ``value`` to the data type of ``type_ref``.
+
+    Only the *type* of ``type_ref`` is used; its value is ignored. This is
+    useful when the target type comes from another column or expression
+    rather than being known up-front. When ``try_cast=True``, casts that
+    fail produce NULL instead of erroring (this dispatches to upstream
+    ``try_cast_to_type``).
+
+    Examples:
+        >>> ctx = dfn.SessionContext()
+        >>> df = ctx.from_pydict({"a": [1], "b": [1.0]})
+        >>> result = df.select(
+        ...     dfn.functions.cast_to_type(
+        ...         dfn.col("a"), dfn.col("b")
+        ...     ).alias("c")
+        ... )
+        >>> result.collect_column("c")[0].as_py()
+        1.0
+
+        >>> df = ctx.from_pydict({"a": ["oops"], "b": [1.0]})
+        >>> result = df.select(
+        ...     dfn.functions.cast_to_type(
+        ...         dfn.col("a"), dfn.col("b"), try_cast=True
+        ...     ).alias("c")
+        ... )
+        >>> result.collect_column("c")[0].as_py() is None
+        True
+    """
+    if try_cast:
+        return Expr(f.try_cast_to_type(value.expr, type_ref.expr))
+    return Expr(f.cast_to_type(value.expr, type_ref.expr))
+
+
 def arrow_metadata(expr: Expr, key: Expr | str | None = None) -> Expr:
     """Returns the metadata of the input expression.
 
@@ -2961,6 +3041,33 @@ def arrow_metadata(expr: Expr, key: Expr | str | None = None) -> Expr:
     if isinstance(key, str):
         key = Expr.string_literal(key)
     return Expr(f.arrow_metadata(expr.expr, key.expr))
+
+
+def with_metadata(expr: Expr, metadata: dict[str, str]) -> Expr:
+    """Attaches Arrow field metadata (key/value pairs) to the input expression.
+
+    This is the inverse of :py:func:`arrow_metadata`. Existing metadata on the
+    input field is preserved; new keys overwrite on collision. Keys must be
+    non-empty strings; empty values are allowed.
+
+    Examples:
+        >>> ctx = dfn.SessionContext()
+        >>> df = ctx.from_pydict({"a": [1]})
+        >>> result = df.select(
+        ...     dfn.functions.with_metadata(
+        ...         dfn.col("a"), {"unit": "ms"}
+        ...     ).alias("a")
+        ... )
+        >>> result.select(
+        ...     dfn.functions.arrow_metadata(dfn.col("a"), "unit").alias("u")
+        ... ).collect_column("u")[0].as_py()
+        'ms'
+    """
+    args = [expr]
+    for k, v in metadata.items():
+        args.append(Expr.string_literal(k))
+        args.append(Expr.string_literal(v))
+    return Expr(f.with_metadata(*(a.expr for a in args)))
 
 
 def get_field(expr: Expr, *names: Expr | str) -> Expr:

--- a/python/datafusion/functions.py
+++ b/python/datafusion/functions.py
@@ -360,6 +360,7 @@ __all__ = [
     "translate",
     "trim",
     "trunc",
+    "try_cast_to_type",
     "union_extract",
     "union_tag",
     "upper",
@@ -2988,13 +2989,13 @@ def arrow_field(expr: Expr) -> Expr:
     return Expr(f.arrow_field(expr.expr))
 
 
-def cast_to_type(value: Expr, type_ref: Expr, *, try_cast: bool = False) -> Expr:
+def cast_to_type(value: Expr, type_ref: Expr) -> Expr:
     """Casts ``value`` to the data type of ``type_ref``.
 
     Only the *type* of ``type_ref`` is used; its value is ignored. This is
     useful when the target type comes from another column or expression
-    rather than being known up-front. When ``try_cast=True``, casts that
-    fail produce NULL instead of erroring.
+    rather than being known up-front. Casts that fail produce an error; use
+    :py:func:`try_cast_to_type` for the NULL-on-failure variant.
 
     If the target type is known statically, prefer :py:func:`arrow_cast`
     (or :py:func:`arrow_try_cast` for the NULL-on-failure variant) and
@@ -3010,17 +3011,32 @@ def cast_to_type(value: Expr, type_ref: Expr, *, try_cast: bool = False) -> Expr
         ... )
         >>> result.collect_column("c")[0].as_py()
         1.0
+    """
+    return Expr(f.cast_to_type(value.expr, type_ref.expr))
 
+
+def try_cast_to_type(value: Expr, type_ref: Expr) -> Expr:
+    """Casts ``value`` to the data type of ``type_ref``, NULL on failure.
+
+    Like :py:func:`cast_to_type`, but casts that fail produce NULL instead
+    of erroring. Only the *type* of ``type_ref`` is used; its value is
+    ignored.
+
+    If the target type is known statically, prefer :py:func:`arrow_try_cast`
+    and pass a type string or ``pyarrow.DataType`` directly.
+
+    Examples:
+        >>> ctx = dfn.SessionContext()
         >>> df = ctx.from_pydict({"a": ["oops"], "b": [1.0]})
         >>> result = df.select(
-        ...     dfn.functions.cast_to_type(
-        ...         dfn.col("a"), dfn.col("b"), try_cast=True
+        ...     dfn.functions.try_cast_to_type(
+        ...         dfn.col("a"), dfn.col("b")
         ...     ).alias("c")
         ... )
         >>> result.collect_column("c")[0].as_py() is None
         True
     """
-    return Expr(f.cast_to_type(value.expr, type_ref.expr, try_cast=try_cast))
+    return Expr(f.try_cast_to_type(value.expr, type_ref.expr))
 
 
 def arrow_metadata(expr: Expr, key: Expr | str | None = None) -> Expr:

--- a/python/datafusion/functions.py
+++ b/python/datafusion/functions.py
@@ -2934,12 +2934,13 @@ def arrow_cast(expr: Expr, data_type: Expr | str | pa.DataType) -> Expr:
     return Expr(f.arrow_cast(expr.expr, data_type.expr))
 
 
-def arrow_try_cast(expr: Expr, data_type: Expr | str) -> Expr:
+def arrow_try_cast(expr: Expr, data_type: Expr | str | pa.DataType) -> Expr:
     """Casts an expression to a specified data type, returning NULL on failure.
 
     Like :py:func:`arrow_cast` but produces NULL instead of erroring when the
     cast cannot be performed. The ``data_type`` may be a string in DataFusion
-    type syntax (for example ``"Float64"``) or an ``Expr`` of string type.
+    type syntax (for example ``"Float64"``), a ``pyarrow.DataType``, or an
+    ``Expr`` of string type.
 
     Examples:
         >>> ctx = dfn.SessionContext()
@@ -2949,7 +2950,17 @@ def arrow_try_cast(expr: Expr, data_type: Expr | str) -> Expr:
         ... )
         >>> result.collect_column("c")[0].as_py() is None
         True
+
+        >>> result = df.select(
+        ...     dfn.functions.arrow_try_cast(
+        ...         dfn.col("a"), data_type=pa.float64()
+        ...     ).alias("c")
+        ... )
+        >>> result.collect_column("c")[0].as_py() is None
+        True
     """
+    if isinstance(data_type, pa.DataType):
+        return expr.try_cast(data_type)
     if isinstance(data_type, str):
         data_type = Expr.string_literal(data_type)
     return Expr(f.arrow_try_cast(expr.expr, data_type.expr))

--- a/python/datafusion/functions.py
+++ b/python/datafusion/functions.py
@@ -2982,8 +2982,7 @@ def cast_to_type(value: Expr, type_ref: Expr, *, try_cast: bool = False) -> Expr
     Only the *type* of ``type_ref`` is used; its value is ignored. This is
     useful when the target type comes from another column or expression
     rather than being known up-front. When ``try_cast=True``, casts that
-    fail produce NULL instead of erroring (this dispatches to upstream
-    ``try_cast_to_type``).
+    fail produce NULL instead of erroring.
 
     Examples:
         >>> ctx = dfn.SessionContext()
@@ -3005,9 +3004,7 @@ def cast_to_type(value: Expr, type_ref: Expr, *, try_cast: bool = False) -> Expr
         >>> result.collect_column("c")[0].as_py() is None
         True
     """
-    if try_cast:
-        return Expr(f.try_cast_to_type(value.expr, type_ref.expr))
-    return Expr(f.cast_to_type(value.expr, type_ref.expr))
+    return Expr(f.cast_to_type(value.expr, type_ref.expr, try_cast=try_cast))
 
 
 def arrow_metadata(expr: Expr, key: Expr | str | None = None) -> Expr:

--- a/python/datafusion/functions.py
+++ b/python/datafusion/functions.py
@@ -2996,6 +2996,10 @@ def cast_to_type(value: Expr, type_ref: Expr, *, try_cast: bool = False) -> Expr
     rather than being known up-front. When ``try_cast=True``, casts that
     fail produce NULL instead of erroring.
 
+    If the target type is known statically, prefer :py:func:`arrow_cast`
+    (or :py:func:`arrow_try_cast` for the NULL-on-failure variant) and
+    pass a type string or ``pyarrow.DataType`` directly.
+
     Examples:
         >>> ctx = dfn.SessionContext()
         >>> df = ctx.from_pydict({"a": [1], "b": [1.0]})

--- a/python/datafusion/functions.py
+++ b/python/datafusion/functions.py
@@ -3058,6 +3058,9 @@ def with_metadata(expr: Expr, metadata: dict[str, str]) -> Expr:
     input field is preserved; new keys overwrite on collision. Keys must be
     non-empty strings; empty values are allowed.
 
+    An empty ``metadata`` dict is a no-op and returns the input expression
+    unchanged. Empty keys raise :py:class:`ValueError`.
+
     Examples:
         >>> ctx = dfn.SessionContext()
         >>> df = ctx.from_pydict({"a": [1]})
@@ -3071,11 +3074,16 @@ def with_metadata(expr: Expr, metadata: dict[str, str]) -> Expr:
         ... ).collect_column("u")[0].as_py()
         'ms'
     """
-    args = [expr]
+    if not metadata:
+        return expr
+    args = [expr.expr]
     for k, v in metadata.items():
-        args.append(Expr.string_literal(k))
-        args.append(Expr.string_literal(v))
-    return Expr(f.with_metadata(*(a.expr for a in args)))
+        if not k:
+            msg = "with_metadata keys must be non-empty strings"
+            raise ValueError(msg)
+        args.append(Expr.string_literal(k).expr)
+        args.append(Expr.string_literal(v).expr)
+    return Expr(f.with_metadata(*args))
 
 
 def get_field(expr: Expr, *names: Expr | str) -> Expr:

--- a/python/datafusion/functions.py
+++ b/python/datafusion/functions.py
@@ -2981,8 +2981,9 @@ def arrow_field(expr: Expr) -> Expr:
         >>> result = df.select(
         ...     dfn.functions.arrow_field(dfn.col("val")).alias("f")
         ... )
-        >>> result.collect_column("f")[0].as_py()["name"]
-        'val'
+        >>> out = result.collect_column("f")[0].as_py()
+        >>> out["name"], out["data_type"], out["nullable"], out["metadata"]
+        ('val', 'Int64', True, [('k', 'v')])
     """
     return Expr(f.arrow_field(expr.expr))
 

--- a/python/tests/test_functions.py
+++ b/python/tests/test_functions.py
@@ -1325,6 +1325,111 @@ def test_arrow_cast_with_pyarrow_type(df):
     assert result.column(2) == pa.array(["4", "5", "6"], type=pa.string())
 
 
+def test_arrow_try_cast(df):
+    df = df.select(
+        f.arrow_try_cast(column("b"), "Float64").alias("b_as_float"),
+        f.arrow_try_cast(column("b"), "Int32").alias("b_as_int"),
+    )
+    result = df.collect()[0]
+
+    assert result.column(0) == pa.array([4.0, 5.0, 6.0], type=pa.float64())
+    assert result.column(1) == pa.array([4, 5, 6], type=pa.int32())
+
+
+def test_arrow_try_cast_with_pyarrow_type(df):
+    df = df.select(
+        f.arrow_try_cast(column("b"), pa.float64()).alias("b_as_float"),
+        f.arrow_try_cast(column("b"), pa.int32()).alias("b_as_int"),
+    )
+    result = df.collect()[0]
+
+    assert result.column(0) == pa.array([4.0, 5.0, 6.0], type=pa.float64())
+    assert result.column(1) == pa.array([4, 5, 6], type=pa.int32())
+
+
+def test_arrow_try_cast_null_on_failure():
+    ctx = SessionContext()
+    batch = pa.RecordBatch.from_arrays([pa.array(["1.5", "oops", "3"])], names=["s"])
+    df = ctx.create_dataframe([[batch]])
+
+    result = df.select(
+        f.arrow_try_cast(column("s"), "Float64").alias("c"),
+        f.arrow_try_cast(column("s"), pa.float64()).alias("c_pa"),
+    ).collect()[0]
+
+    assert result.column(0).to_pylist() == [1.5, None, 3.0]
+    assert result.column(1).to_pylist() == [1.5, None, 3.0]
+
+
+def test_arrow_field():
+    ctx = SessionContext()
+    field = pa.field("val", pa.int64(), metadata={"k": "v"})
+    schema = pa.schema([field])
+    batch = pa.RecordBatch.from_arrays([pa.array([1])], schema=schema)
+    df = ctx.create_dataframe([[batch]])
+
+    out = (
+        df.select(f.arrow_field(column("val")).alias("f"))
+        .collect_column("f")[0]
+        .as_py()
+    )
+    assert out == {
+        "name": "val",
+        "data_type": "Int64",
+        "nullable": True,
+        "metadata": [("k", "v")],
+    }
+
+
+def test_cast_to_type():
+    ctx = SessionContext()
+    batch = pa.RecordBatch.from_arrays(
+        [pa.array([4, 5, 6]), pa.array([1.0, 2.0, 3.0])],
+        names=["b", "fl"],
+    )
+    df = ctx.create_dataframe([[batch]])
+
+    result = df.select(f.cast_to_type(column("b"), column("fl")).alias("c")).collect()[
+        0
+    ]
+
+    assert result.column(0) == pa.array([4.0, 5.0, 6.0], type=pa.float64())
+
+
+def test_cast_to_type_try_cast_null_on_failure():
+    ctx = SessionContext()
+    batch = pa.RecordBatch.from_arrays(
+        [pa.array(["oops", "2", "3"]), pa.array([1.0, 2.0, 3.0])],
+        names=["a", "fl"],
+    )
+    df = ctx.create_dataframe([[batch]])
+
+    result = df.select(
+        f.cast_to_type(column("a"), column("fl"), try_cast=True).alias("c")
+    ).collect()[0]
+
+    assert result.column(0).to_pylist() == [None, 2.0, 3.0]
+    assert result.column(0).type == pa.float64()
+
+
+def test_with_metadata_round_trip(df):
+    df = df.select(f.with_metadata(column("b"), {"unit": "ms"}).alias("b"))
+    result = df.select(f.arrow_metadata(column("b"), "unit").alias("u")).collect_column(
+        "u"
+    )
+    assert result[0].as_py() == "ms"
+
+
+def test_with_metadata_empty_dict_noop(df):
+    out = df.select(f.with_metadata(column("b"), {}).alias("b")).collect()[0]
+    assert out.column(0) == pa.array([4, 5, 6])
+
+
+def test_with_metadata_empty_key_raises(df):
+    with pytest.raises(ValueError, match="non-empty"):
+        f.with_metadata(column("b"), {"": "v"})
+
+
 def test_case(df):
     df = df.select(
         f.case(column("b")).when(literal(4), literal(10)).otherwise(literal(8)),

--- a/python/tests/test_functions.py
+++ b/python/tests/test_functions.py
@@ -1316,13 +1316,12 @@ def test_arrow_cast_variants(df, cast_fn, data_type, expected):
     assert result.column(0) == expected
 
 
-@pytest.mark.parametrize("data_type", ["Float64", pa.float64()])
-def test_arrow_try_cast_null_on_failure(data_type):
+def test_arrow_try_cast_null_on_failure():
     ctx = SessionContext()
     batch = pa.RecordBatch.from_arrays([pa.array(["1.5", "oops", "3"])], names=["s"])
     df = ctx.create_dataframe([[batch]])
 
-    result = df.select(f.arrow_try_cast(column("s"), data_type).alias("c")).collect()[0]
+    result = df.select(f.arrow_try_cast(column("s"), "Float64").alias("c")).collect()[0]
 
     assert result.column(0).to_pylist() == [1.5, None, 3.0]
 
@@ -1348,23 +1347,21 @@ def test_arrow_field():
 
 
 @pytest.mark.parametrize(
-    ("values", "try_cast", "expected"),
+    ("cast_fn", "values", "expected"),
     [
-        (pa.array([4, 5, 6]), False, [4.0, 5.0, 6.0]),
-        (pa.array(["oops", "2", "3"]), True, [None, 2.0, 3.0]),
+        (f.cast_to_type, pa.array([4, 5, 6]), [4.0, 5.0, 6.0]),
+        (f.try_cast_to_type, pa.array(["oops", "2", "3"]), [None, 2.0, 3.0]),
     ],
 )
-def test_cast_to_type(values, try_cast, expected):
-    """cast_to_type takes target type from ``type_ref``; try_cast nullifies failures."""
+def test_cast_to_type(cast_fn, values, expected):
+    """cast_to_type / try_cast_to_type take target type from ``type_ref``."""
     ctx = SessionContext()
     batch = pa.RecordBatch.from_arrays(
         [values, pa.array([1.0, 2.0, 3.0])], names=["v", "fl"]
     )
     df = ctx.create_dataframe([[batch]])
 
-    result = df.select(
-        f.cast_to_type(column("v"), column("fl"), try_cast=try_cast).alias("c")
-    ).collect()[0]
+    result = df.select(cast_fn(column("v"), column("fl")).alias("c")).collect()[0]
 
     assert result.column(0).to_pylist() == expected
     assert result.column(0).type == pa.float64()

--- a/python/tests/test_functions.py
+++ b/python/tests/test_functions.py
@@ -1299,66 +1299,32 @@ def test_make_time(df):
     assert result.column(0)[0].as_py() == time(12, 30)
 
 
-def test_arrow_cast(df):
-    df = df.select(
-        f.arrow_cast(column("b"), "Float64").alias("b_as_float"),
-        f.arrow_cast(column("b"), "Int32").alias("b_as_int"),
-    )
-    result = df.collect()
-    assert len(result) == 1
-    result = result[0]
-
-    assert result.column(0) == pa.array([4.0, 5.0, 6.0], type=pa.float64())
-    assert result.column(1) == pa.array([4, 5, 6], type=pa.int32())
-
-
-def test_arrow_cast_with_pyarrow_type(df):
-    df = df.select(
-        f.arrow_cast(column("b"), pa.float64()).alias("b_as_float"),
-        f.arrow_cast(column("b"), pa.int32()).alias("b_as_int"),
-        f.arrow_cast(column("b"), pa.string()).alias("b_as_str"),
-    )
-    result = df.collect()[0]
-
-    assert result.column(0) == pa.array([4.0, 5.0, 6.0], type=pa.float64())
-    assert result.column(1) == pa.array([4, 5, 6], type=pa.int32())
-    assert result.column(2) == pa.array(["4", "5", "6"], type=pa.string())
+@pytest.mark.parametrize("cast_fn", [f.arrow_cast, f.arrow_try_cast])
+@pytest.mark.parametrize(
+    ("data_type", "expected"),
+    [
+        ("Float64", pa.array([4.0, 5.0, 6.0], type=pa.float64())),
+        ("Int32", pa.array([4, 5, 6], type=pa.int32())),
+        (pa.float64(), pa.array([4.0, 5.0, 6.0], type=pa.float64())),
+        (pa.int32(), pa.array([4, 5, 6], type=pa.int32())),
+        (pa.string(), pa.array(["4", "5", "6"], type=pa.string())),
+    ],
+)
+def test_arrow_cast_variants(df, cast_fn, data_type, expected):
+    """arrow_cast / arrow_try_cast accept str and pyarrow target types."""
+    result = df.select(cast_fn(column("b"), data_type).alias("c")).collect()[0]
+    assert result.column(0) == expected
 
 
-def test_arrow_try_cast(df):
-    df = df.select(
-        f.arrow_try_cast(column("b"), "Float64").alias("b_as_float"),
-        f.arrow_try_cast(column("b"), "Int32").alias("b_as_int"),
-    )
-    result = df.collect()[0]
-
-    assert result.column(0) == pa.array([4.0, 5.0, 6.0], type=pa.float64())
-    assert result.column(1) == pa.array([4, 5, 6], type=pa.int32())
-
-
-def test_arrow_try_cast_with_pyarrow_type(df):
-    df = df.select(
-        f.arrow_try_cast(column("b"), pa.float64()).alias("b_as_float"),
-        f.arrow_try_cast(column("b"), pa.int32()).alias("b_as_int"),
-    )
-    result = df.collect()[0]
-
-    assert result.column(0) == pa.array([4.0, 5.0, 6.0], type=pa.float64())
-    assert result.column(1) == pa.array([4, 5, 6], type=pa.int32())
-
-
-def test_arrow_try_cast_null_on_failure():
+@pytest.mark.parametrize("data_type", ["Float64", pa.float64()])
+def test_arrow_try_cast_null_on_failure(data_type):
     ctx = SessionContext()
     batch = pa.RecordBatch.from_arrays([pa.array(["1.5", "oops", "3"])], names=["s"])
     df = ctx.create_dataframe([[batch]])
 
-    result = df.select(
-        f.arrow_try_cast(column("s"), "Float64").alias("c"),
-        f.arrow_try_cast(column("s"), pa.float64()).alias("c_pa"),
-    ).collect()[0]
+    result = df.select(f.arrow_try_cast(column("s"), data_type).alias("c")).collect()[0]
 
     assert result.column(0).to_pylist() == [1.5, None, 3.0]
-    assert result.column(1).to_pylist() == [1.5, None, 3.0]
 
 
 def test_arrow_field():
@@ -1381,34 +1347,26 @@ def test_arrow_field():
     }
 
 
-def test_cast_to_type():
+@pytest.mark.parametrize(
+    ("values", "try_cast", "expected"),
+    [
+        (pa.array([4, 5, 6]), False, [4.0, 5.0, 6.0]),
+        (pa.array(["oops", "2", "3"]), True, [None, 2.0, 3.0]),
+    ],
+)
+def test_cast_to_type(values, try_cast, expected):
+    """cast_to_type takes target type from ``type_ref``; try_cast nullifies failures."""
     ctx = SessionContext()
     batch = pa.RecordBatch.from_arrays(
-        [pa.array([4, 5, 6]), pa.array([1.0, 2.0, 3.0])],
-        names=["b", "fl"],
-    )
-    df = ctx.create_dataframe([[batch]])
-
-    result = df.select(f.cast_to_type(column("b"), column("fl")).alias("c")).collect()[
-        0
-    ]
-
-    assert result.column(0) == pa.array([4.0, 5.0, 6.0], type=pa.float64())
-
-
-def test_cast_to_type_try_cast_null_on_failure():
-    ctx = SessionContext()
-    batch = pa.RecordBatch.from_arrays(
-        [pa.array(["oops", "2", "3"]), pa.array([1.0, 2.0, 3.0])],
-        names=["a", "fl"],
+        [values, pa.array([1.0, 2.0, 3.0])], names=["v", "fl"]
     )
     df = ctx.create_dataframe([[batch]])
 
     result = df.select(
-        f.cast_to_type(column("a"), column("fl"), try_cast=True).alias("c")
+        f.cast_to_type(column("v"), column("fl"), try_cast=try_cast).alias("c")
     ).collect()[0]
 
-    assert result.column(0).to_pylist() == [None, 2.0, 3.0]
+    assert result.column(0).to_pylist() == expected
     assert result.column(0).type == pa.float64()
 
 
@@ -1425,7 +1383,7 @@ def test_with_metadata_empty_dict_noop(df):
     assert out.column(0) == pa.array([4, 5, 6])
 
 
-def test_with_metadata_empty_key_raises(df):
+def test_with_metadata_empty_key_raises():
     with pytest.raises(ValueError, match="non-empty"):
         f.with_metadata(column("b"), {"": "v"})
 

--- a/skills/datafusion_python/SKILL.md
+++ b/skills/datafusion_python/SKILL.md
@@ -758,7 +758,12 @@ F.left(col("c_phone"), lit(2))                # prefix shortcut
 
 **Hash**: `md5`, `sha224`, `sha256`, `sha384`, `sha512`, `digest`
 
-**Type**: `arrow_typeof`, `arrow_cast`, `arrow_metadata`
+**Type**: `arrow_typeof`, `arrow_cast`, `arrow_try_cast`, `arrow_field`,
+`arrow_metadata`, `cast_to_type`, `with_metadata`
+
+Note: ``cast_to_type(value, type_ref, *, try_cast=False)`` is the single
+Python entry point for both upstream ``cast_to_type`` and ``try_cast_to_type``;
+pass ``try_cast=True`` for the variant that returns NULL on failure.
 
 **Other**: `in_list`, `order_by`, `alias`, `col`, `encode`, `decode`,
 `to_hex`, `to_char`, `uuid`, `version`, `bit_length`, `octet_length`


### PR DESCRIPTION
# Which issue does this PR close?

No tracking issue; gap surfaced during the v54 upstream coverage audit.

# Rationale for this change

Five scalar functions from `datafusion::functions::expr_fn` (DataFusion 54) were not exposed through the Python bindings. They round out the Arrow type-introspection and casting surface alongside the existing `arrow_typeof`, `arrow_cast`, and `arrow_metadata` wrappers.

# What changes are included in this PR?

- Exposed functions
- Add docstring tests or unit tests as appropriate
- `skills/datafusion_python/SKILL.md`: list the new functions and document the `cast_to_type` kwarg behavior so users understand the single-entry-point design.

# Are there any user-facing changes?

Yes. Five new public functions in `datafusion.functions`:

- `arrow_field(expr)`
- `arrow_try_cast(expr, data_type)`
- `cast_to_type(value, type_ref, *, try_cast=False)`
- `with_metadata(expr, metadata)`

No breaking changes.