### PR TITLE
feat: expose SessionContext.write_csv, write_json, write_parquet

### DIFF
--- a/crates/core/src/context.rs
+++ b/crates/core/src/context.rs
@@ -44,6 +44,7 @@ use datafusion::execution::options::{ArrowReadOptions, ReadOptions};
 use datafusion::execution::runtime_env::RuntimeEnvBuilder;
 use datafusion::execution::session_state::SessionStateBuilder;
 use datafusion::execution::{FunctionRegistry, TaskContextProvider};
+use datafusion::physical_plan::ExecutionPlan;
 use datafusion::prelude::{
     AvroReadOptions, CsvReadOptions, DataFrame, JsonReadOptions, ParquetReadOptions,
 };
@@ -1408,6 +1409,42 @@ impl PySessionContext {
         let plan = plan.plan.clone();
         let stream = spawn_future(py, async move { plan.execute(part, Arc::new(ctx)) })?;
         Ok(PyRecordBatchStream::new(stream))
+    }
+
+    /// Execute an `ExecutionPlan` and write the results to a partitioned CSV file at `path`.
+    pub fn write_csv(
+        &self,
+        plan: PyExecutionPlan,
+        path: &str,
+        py: Python,
+    ) -> PyDataFusionResult<()> {
+        let plan: Arc<dyn ExecutionPlan> = plan.into();
+        wait_for_future(py, self.ctx.write_csv(plan, path))??;
+        Ok(())
+    }
+
+    /// Execute an `ExecutionPlan` and write the results to a partitioned newline-delimited JSON file at `path`.
+    pub fn write_json(
+        &self,
+        plan: PyExecutionPlan,
+        path: &str,
+        py: Python,
+    ) -> PyDataFusionResult<()> {
+        let plan: Arc<dyn ExecutionPlan> = plan.into();
+        wait_for_future(py, self.ctx.write_json(plan, path))??;
+        Ok(())
+    }
+
+    /// Execute an `ExecutionPlan` and write the results to a partitioned Parquet file at `path`.
+    pub fn write_parquet(
+        &self,
+        plan: PyExecutionPlan,
+        path: &str,
+        py: Python,
+    ) -> PyDataFusionResult<()> {
+        let plan: Arc<dyn ExecutionPlan> = plan.into();
+        wait_for_future(py, self.ctx.write_parquet(plan, path, None))??;
+        Ok(())
     }
 
     pub fn __datafusion_task_context_provider__<'py>(

--- a/python/datafusion/context.py
+++ b/python/datafusion/context.py
@@ -1902,6 +1902,63 @@ class SessionContext:
         """Execute the ``plan`` and return the results."""
         return RecordBatchStream(self.ctx.execute(plan._raw_plan, partitions))
 
+    def write_csv(self, plan: ExecutionPlan, path: str | pathlib.Path) -> None:
+        """Execute ``plan`` and write the results to a partitioned CSV file.
+
+        ``path`` is treated as a directory; one file per partition is written
+        inside it. For per-DataFrame writes with options (header control,
+        write options), use :py:meth:`DataFrame.write_csv` instead.
+
+        Examples:
+            >>> import tempfile, pathlib
+            >>> ctx = dfn.SessionContext()
+            >>> df = ctx.from_pydict({"a": [1, 2, 3]})
+            >>> with tempfile.TemporaryDirectory() as tmp:
+            ...     out = pathlib.Path(tmp) / "out"
+            ...     ctx.write_csv(df.execution_plan(), str(out))
+            ...     sorted(p.suffix for p in out.iterdir())
+            ['.csv']
+        """
+        self.ctx.write_csv(plan._raw_plan, str(path))
+
+    def write_json(self, plan: ExecutionPlan, path: str | pathlib.Path) -> None:
+        """Execute ``plan`` and write the results to a partitioned NDJSON file.
+
+        ``path`` is treated as a directory; one newline-delimited JSON file
+        per partition is written inside it. For per-DataFrame writes with
+        options, use :py:meth:`DataFrame.write_json` instead.
+
+        Examples:
+            >>> import tempfile, pathlib
+            >>> ctx = dfn.SessionContext()
+            >>> df = ctx.from_pydict({"a": [1, 2, 3]})
+            >>> with tempfile.TemporaryDirectory() as tmp:
+            ...     out = pathlib.Path(tmp) / "out"
+            ...     ctx.write_json(df.execution_plan(), str(out))
+            ...     sorted(p.suffix for p in out.iterdir())
+            ['.json']
+        """
+        self.ctx.write_json(plan._raw_plan, str(path))
+
+    def write_parquet(self, plan: ExecutionPlan, path: str | pathlib.Path) -> None:
+        """Execute ``plan`` and write the results to a partitioned Parquet file.
+
+        ``path`` is treated as a directory; one Parquet file per partition is
+        written inside it. For per-DataFrame writes with compression and
+        writer options, use :py:meth:`DataFrame.write_parquet` instead.
+
+        Examples:
+            >>> import tempfile, pathlib
+            >>> ctx = dfn.SessionContext()
+            >>> df = ctx.from_pydict({"a": [1, 2, 3]})
+            >>> with tempfile.TemporaryDirectory() as tmp:
+            ...     out = pathlib.Path(tmp) / "out"
+            ...     ctx.write_parquet(df.execution_plan(), str(out))
+            ...     sorted(p.suffix for p in out.iterdir())
+            ['.parquet']
+        """
+        self.ctx.write_parquet(plan._raw_plan, str(path))
+
     @staticmethod
     def _convert_file_sort_order(
         file_sort_order: Sequence[Sequence[SortKey]] | None,


### PR DESCRIPTION
# Which issue does this PR close?

Closes #. No dedicated tracking issue; related to umbrella issue #462 (interface design / user stories).

# Rationale for this change

DataFusion's `SessionContext` exposes `write_csv`, `write_json`, and `write_parquet` methods that take an already-built `Arc<dyn ExecutionPlan>` and a target path. These complement the existing per-`DataFrame` write methods and are the right entry point when a caller already holds a physical plan -- for example after running custom physical optimizer rules (recently exposed via PR #1557) or after constructing a plan directly. The Python bindings did not surface them.

# What changes are included in this PR?

- `crates/core/src/context.rs`: add `write_csv`, `write_json`, and `write_parquet` PyO3 methods on `PySessionContext`. Each accepts a `PyExecutionPlan` and a path, converts the plan to `Arc<dyn ExecutionPlan>`, and delegates to the matching upstream `SessionContext` method. `write_parquet` passes `None` for the `WriterProperties` argument; per-partition Parquet tuning remains on `DataFrame.write_parquet`.
- `python/datafusion/context.py`: add Python wrappers with doctest examples that round-trip data through a temp directory. The docstrings flag `DataFrame.write_*` as the right entry point when callers need header control, compression, or other write options.

# Are there any user-facing changes?

Yes. Three new public methods on `datafusion.SessionContext`:

- `write_csv(plan, path)`
- `write_json(plan, path)`
- `write_parquet(plan, path)`

No breaking changes.