### PR TITLE
Deprecate `Expr` temporal part arguments in date extraction and truncation functions

### DIFF
--- a/docs/source/user-guide/common-operations/functions.rst
+++ b/docs/source/user-guide/common-operations/functions.rst
@@ -77,8 +77,8 @@ Extracting parts of a date using :py:func:`~datafusion.functions.date_part` (ali
 .. ipython:: python
 
      df.select(
-        f.date_part(literal("month"), f.to_timestamp(col('"Total"'))).alias("month"),
-        f.extract(literal("day"), f.to_timestamp(col('"Total"'))).alias("day")
+        f.date_part("month", f.to_timestamp(col('"Total"'))).alias("month"),
+        f.extract("day", f.to_timestamp(col('"Total"'))).alias("day")
      )
   
 String

--- a/python/datafusion/functions.py
+++ b/python/datafusion/functions.py
@@ -67,7 +67,7 @@ def _warn_expr_for_literal_arg(function_name: str, arg_name: str) -> None:
         f"Passing Expr for {function_name}() argument {arg_name!r} is deprecated; "
         "pass a Python literal instead.",
         DeprecationWarning,
-        stacklevel=3,
+        stacklevel=4,
     )
 
 

--- a/python/datafusion/functions.py
+++ b/python/datafusion/functions.py
@@ -39,6 +39,7 @@ for categorized catalogs of aggregate and window functions.
 from __future__ import annotations
 
 import inspect
+import warnings
 from typing import TYPE_CHECKING, Any
 
 import pyarrow as pa
@@ -59,6 +60,16 @@ from datafusion.expr import (
     sort_list_to_raw_sort_list,
     sort_or_default,
 )
+
+
+def _warn_expr_for_literal_arg(function_name: str, arg_name: str) -> None:
+    warnings.warn(
+        f"Passing Expr for {function_name}() argument {arg_name!r} is deprecated; "
+        "pass a Python literal instead.",
+        DeprecationWarning,
+        stacklevel=3,
+    )
+
 
 __all__ = [
     "abs",
@@ -2575,7 +2586,7 @@ def datepart(part: Expr | str, date: Expr) -> Expr:
     See Also:
         This is an alias for :py:func:`date_part`.
     """
-    return date_part(part, date)
+    return _date_part(part, date, "datepart")
 
 
 def date_part(part: Expr | str, date: Expr) -> Expr:
@@ -2595,6 +2606,12 @@ def date_part(part: Expr | str, date: Expr) -> Expr:
         >>> result.collect_column("y")[0].as_py()
         2021
     """
+    return _date_part(part, date, "date_part")
+
+
+def _date_part(part: Expr | str, date: Expr, function_name: str) -> Expr:
+    if isinstance(part, Expr):
+        _warn_expr_for_literal_arg(function_name, "part")
     part = coerce_to_expr(part)
     return Expr(f.date_part(part.expr, date.expr))
 
@@ -2605,7 +2622,7 @@ def extract(part: Expr | str, date: Expr) -> Expr:
     See Also:
         This is an alias for :py:func:`date_part`.
     """
-    return date_part(part, date)
+    return _date_part(part, date, "extract")
 
 
 def date_trunc(part: Expr | str, date: Expr) -> Expr:
@@ -2626,6 +2643,12 @@ def date_trunc(part: Expr | str, date: Expr) -> Expr:
         >>> str(result.collect_column("t")[0].as_py())
         '2021-07-01 00:00:00'
     """
+    return _date_trunc(part, date, "date_trunc")
+
+
+def _date_trunc(part: Expr | str, date: Expr, function_name: str) -> Expr:
+    if isinstance(part, Expr):
+        _warn_expr_for_literal_arg(function_name, "part")
     part = coerce_to_expr(part)
     return Expr(f.date_trunc(part.expr, date.expr))
 
@@ -2636,7 +2659,7 @@ def datetrunc(part: Expr | str, date: Expr) -> Expr:
     See Also:
         This is an alias for :py:func:`date_trunc`.
     """
-    return date_trunc(part, date)
+    return _date_trunc(part, date, "datetrunc")
 
 
 def date_bin(stride: Expr, source: Expr, origin: Expr) -> Expr:

--- a/python/tests/test_functions.py
+++ b/python/tests/test_functions.py
@@ -2157,14 +2157,11 @@ class TestPythonicNativeTypes:
         result = df.select(f.encode(column("a"), "base64").alias("e")).collect()
         assert result[0].column(0)[0].as_py() == "aGVsbG8"
 
-    def test_date_part_native_str(self):
-        ctx = SessionContext()
-        df = ctx.from_pydict({"a": ["2021-07-15T00:00:00"]})
-        df = df.select(f.to_timestamp(column("a")).alias("a"))
+    def test_date_part_native_str_no_deprecation_warning(self):
         with warnings.catch_warnings():
             warnings.simplefilter("error", DeprecationWarning)
-            result = df.select(f.date_part("year", column("a")).alias("y")).collect()
-        assert result[0].column(0)[0].as_py() == 2021
+            expr = f.date_part("year", column("a"))
+        assert expr is not None
 
     @pytest.mark.parametrize(
         ("func", "name"),
@@ -2182,14 +2179,11 @@ class TestPythonicNativeTypes:
             expr = func(literal("year"), column("a"))
         assert expr is not None
 
-    def test_date_trunc_native_str(self):
-        ctx = SessionContext()
-        df = ctx.from_pydict({"a": ["2021-07-15T12:34:56"]})
-        df = df.select(f.to_timestamp(column("a")).alias("a"))
+    def test_date_trunc_native_str_no_deprecation_warning(self):
         with warnings.catch_warnings():
             warnings.simplefilter("error", DeprecationWarning)
-            result = df.select(f.date_trunc("month", column("a")).alias("t")).collect()
-        assert str(result[0].column(0)[0].as_py()) == "2021-07-01 00:00:00"
+            expr = f.date_trunc("month", column("a"))
+        assert expr is not None
 
     @pytest.mark.parametrize(
         ("func", "name"),

--- a/python/tests/test_functions.py
+++ b/python/tests/test_functions.py
@@ -2157,11 +2157,14 @@ class TestPythonicNativeTypes:
         result = df.select(f.encode(column("a"), "base64").alias("e")).collect()
         assert result[0].column(0)[0].as_py() == "aGVsbG8"
 
-    def test_date_part_native_str_no_deprecation_warning(self):
+    def test_date_part_native_str(self):
+        ctx = SessionContext()
+        df = ctx.from_pydict({"a": ["2021-07-15T00:00:00"]})
+        df = df.select(f.to_timestamp(column("a")).alias("a"))
         with warnings.catch_warnings():
             warnings.simplefilter("error", DeprecationWarning)
-            expr = f.date_part("year", column("a"))
-        assert expr is not None
+            result = df.select(f.date_part("year", column("a")).alias("y")).collect()
+        assert result[0].column(0)[0].as_py() == 2021
 
     @pytest.mark.parametrize(
         ("func", "name"),
@@ -2179,11 +2182,14 @@ class TestPythonicNativeTypes:
             expr = func(literal("year"), column("a"))
         assert expr is not None
 
-    def test_date_trunc_native_str_no_deprecation_warning(self):
+    def test_date_trunc_native_str(self):
+        ctx = SessionContext()
+        df = ctx.from_pydict({"a": ["2021-07-15T12:34:56"]})
+        df = df.select(f.to_timestamp(column("a")).alias("a"))
         with warnings.catch_warnings():
             warnings.simplefilter("error", DeprecationWarning)
-            expr = f.date_trunc("month", column("a"))
-        assert expr is not None
+            result = df.select(f.date_trunc("month", column("a")).alias("t")).collect()
+        assert str(result[0].column(0)[0].as_py()) == "2021-07-01 00:00:00"
 
     @pytest.mark.parametrize(
         ("func", "name"),

--- a/python/tests/test_functions.py
+++ b/python/tests/test_functions.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import math
+import warnings
 from datetime import date, datetime, time, timezone
 
 import numpy as np
@@ -1086,10 +1087,10 @@ def test_hash_functions(df):
 
 def test_temporal_functions(df):
     df = df.select(
-        f.date_part(literal("month"), column("d")),
-        f.datepart(literal("year"), column("d")),
-        f.date_trunc(literal("month"), column("d")),
-        f.datetrunc(literal("day"), column("d")),
+        f.date_part("month", column("d")),
+        f.datepart("year", column("d")),
+        f.date_trunc("month", column("d")),
+        f.datetrunc("day", column("d")),
         f.date_bin(
             literal("15 minutes").cast(pa.string()),
             column("d"),
@@ -1100,7 +1101,7 @@ def test_temporal_functions(df):
         f.to_timestamp_seconds(literal("2023-09-07 05:06:14.523952")),
         f.to_timestamp_millis(literal("2023-09-07 05:06:14.523952")),
         f.to_timestamp_micros(literal("2023-09-07 05:06:14.523952")),
-        f.extract(literal("day"), column("d")),
+        f.extract("day", column("d")),
         f.to_timestamp(
             literal("2023-09-07 05:06:14.523952000"), literal("%Y-%m-%d %H:%M:%S.%f")
         ),
@@ -2160,15 +2161,50 @@ class TestPythonicNativeTypes:
         ctx = SessionContext()
         df = ctx.from_pydict({"a": ["2021-07-15T00:00:00"]})
         df = df.select(f.to_timestamp(column("a")).alias("a"))
-        result = df.select(f.date_part("year", column("a")).alias("y")).collect()
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            result = df.select(f.date_part("year", column("a")).alias("y")).collect()
         assert result[0].column(0)[0].as_py() == 2021
+
+    @pytest.mark.parametrize(
+        ("func", "name"),
+        [
+            pytest.param(f.date_part, "date_part", id="date_part"),
+            pytest.param(f.datepart, "datepart", id="datepart"),
+            pytest.param(f.extract, "extract", id="extract"),
+        ],
+    )
+    def test_date_part_expr_part_warns_deprecated(self, func, name):
+        with pytest.warns(
+            DeprecationWarning,
+            match=rf"Passing Expr for {name}\(\) argument 'part' is deprecated",
+        ):
+            expr = func(literal("year"), column("a"))
+        assert expr is not None
 
     def test_date_trunc_native_str(self):
         ctx = SessionContext()
         df = ctx.from_pydict({"a": ["2021-07-15T12:34:56"]})
         df = df.select(f.to_timestamp(column("a")).alias("a"))
-        result = df.select(f.date_trunc("month", column("a")).alias("t")).collect()
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            result = df.select(f.date_trunc("month", column("a")).alias("t")).collect()
         assert str(result[0].column(0)[0].as_py()) == "2021-07-01 00:00:00"
+
+    @pytest.mark.parametrize(
+        ("func", "name"),
+        [
+            pytest.param(f.date_trunc, "date_trunc", id="date_trunc"),
+            pytest.param(f.datetrunc, "datetrunc", id="datetrunc"),
+        ],
+    )
+    def test_date_trunc_expr_part_warns_deprecated(self, func, name):
+        with pytest.warns(
+            DeprecationWarning,
+            match=rf"Passing Expr for {name}\(\) argument 'part' is deprecated",
+        ):
+            expr = func(literal("month"), column("a"))
+        assert expr is not None
 
     def test_left_native_int(self):
         ctx = SessionContext()


### PR DESCRIPTION
## Which issue does this PR close?

* Part of #1496

## Rationale for this change

Temporal functions such as `date_part`, `date_trunc`, and their aliases conceptually expect a literal date/time part (for example, `"year"` or `"month"`). While the current API also accepts an `Expr`, that usage is confusing because it suggests arbitrary expressions are intended inputs.

This change begins the deprecation process by warning when an `Expr` is passed for the `part` argument while preserving existing runtime behavior. 

## What changes are included in this PR?

* Added a shared helper to emit a `DeprecationWarning` when an `Expr` is passed to a literal control argument.
* Updated the implementations of:

  * `date_part`
  * `datepart`
  * `extract`
  * `date_trunc`
  * `datetrunc`

  to warn when `part` is provided as an `Expr`.
* Refactored alias functions (`datepart`, `extract`, and `datetrunc`) to delegate through internal helper functions so warnings reference the user-facing function name correctly and avoid duplicate warning behavior.
* Updated existing temporal function tests to use the preferred string-literal form for `part`.
* Added targeted tests verifying:

  * `Expr` inputs emit `DeprecationWarning` for `date_part`, `datepart`, and `extract`.
  * `Expr` inputs emit `DeprecationWarning` for `date_trunc` and `datetrunc`.
  * String literal inputs continue to work without emitting deprecation warnings. 

## Are these changes tested?

Yes.

The PR updates existing temporal function tests and adds the following deprecation-focused test coverage:

* `test_date_part_expr_part_warns_deprecated`
* `test_date_trunc_expr_part_warns_deprecated`

It also verifies that preferred string-literal usage does not emit `DeprecationWarning` by running:

* `test_date_part_native_str`
* `test_date_trunc_native_str`

with deprecation warnings treated as errors. 

## Are there any user-facing changes?

Yes.

Passing an `Expr` (for example, `literal("year")`) as the `part` argument to temporal extraction and truncation functions now emits a `DeprecationWarning` advising users to pass a Python literal string instead.

Runtime behavior and query results remain unchanged in this release. 

## LLM-generated code disclosure

This PR includes code, comments generated with assistance from LLM. All LLM-generated content has been manually reviewed and tested.
