### PR TITLE
Add deprecation warnings for Expr passed to confirmed literal-only function arguments

### DIFF
--- a/docs/source/user-guide/common-operations/functions.md
+++ b/docs/source/user-guide/common-operations/functions.md
@@ -52,7 +52,7 @@ df = ctx.table("pokemon")
 DataFusion offers mathematical functions such as {py:func}`~datafusion.functions.pow` or {py:func}`~datafusion.functions.log`
 
 ```{code-cell} ipython3
-from datafusion import col, literal, string_literal, str_lit
+from datafusion import col, literal
 from datafusion import functions as f
 
 df.select(
@@ -122,8 +122,8 @@ Casting expressions to different data types using {py:func}`~datafusion.function
 
 ```{code-cell} ipython3
 df.select(
-    f.arrow_cast(col('"Total"'), string_literal("Float64")).alias("total_as_float"),
-    f.arrow_cast(col('"Total"'), str_lit("Int32")).alias("total_as_int")
+    f.arrow_cast(col('"Total"'), "Float64").alias("total_as_float"),
+    f.arrow_cast(col('"Total"'), "Int32").alias("total_as_int")
 )
 ```
 

--- a/python/datafusion/functions/__init__.py
+++ b/python/datafusion/functions/__init__.py
@@ -64,20 +64,16 @@ from datafusion.expr import (
 from datafusion.functions import spark
 
 
-def _warn_expr_for_literal_arg(function_name: str, arg_name: str) -> None:
-    warnings.warn(
-        f"Passing Expr for {function_name}() argument {arg_name!r} is deprecated; "
-        "pass a Python literal instead.",
-        DeprecationWarning,
-        stacklevel=4,
-    )
-
-
 def _warn_if_expr_for_literal_arg(
     value: Any, function_name: str, arg_name: str
 ) -> None:
     if isinstance(value, Expr):
-        _warn_expr_for_literal_arg(function_name, arg_name)
+        warnings.warn(
+            f"Passing Expr for {function_name}() argument {arg_name!r} is deprecated; "
+            "pass a Python literal instead.",
+            DeprecationWarning,
+            stacklevel=3,
+        )
 
 
 __all__ = [
@@ -2733,8 +2729,7 @@ def date_part(part: Expr | str, date: Expr) -> Expr:
 
 
 def _date_part(part: Expr | str, date: Expr, function_name: str) -> Expr:
-    if isinstance(part, Expr):
-        _warn_expr_for_literal_arg(function_name, "part")
+    _warn_if_expr_for_literal_arg(part, function_name, "part")
     part = coerce_to_expr(part)
     return Expr(f.date_part(part.expr, date.expr))
 
@@ -2770,8 +2765,7 @@ def date_trunc(part: Expr | str, date: Expr) -> Expr:
 
 
 def _date_trunc(part: Expr | str, date: Expr, function_name: str) -> Expr:
-    if isinstance(part, Expr):
-        _warn_expr_for_literal_arg(function_name, "part")
+    _warn_if_expr_for_literal_arg(part, function_name, "part")
     part = coerce_to_expr(part)
     return Expr(f.date_trunc(part.expr, date.expr))
 

--- a/python/datafusion/functions/__init__.py
+++ b/python/datafusion/functions/__init__.py
@@ -73,6 +73,13 @@ def _warn_expr_for_literal_arg(function_name: str, arg_name: str) -> None:
     )
 
 
+def _warn_if_expr_for_literal_arg(
+    value: Any, function_name: str, arg_name: str
+) -> None:
+    if isinstance(value, Expr):
+        _warn_expr_for_literal_arg(function_name, arg_name)
+
+
 __all__ = [
     "abs",
     "acos",
@@ -437,6 +444,7 @@ def encode(expr: Expr, encoding: Expr | str) -> Expr:
         >>> result.collect_column("enc")[0].as_py()
         'aGVsbG8'
     """
+    _warn_if_expr_for_literal_arg(encoding, "encode", "encoding")
     encoding = coerce_to_expr(encoding)
     return Expr(f.encode(expr.expr, encoding.expr))
 
@@ -452,6 +460,7 @@ def decode(expr: Expr, encoding: Expr | str) -> Expr:
         >>> result.collect_column("dec")[0].as_py()
         b'hello'
     """
+    _warn_if_expr_for_literal_arg(encoding, "decode", "encoding")
     encoding = coerce_to_expr(encoding)
     return Expr(f.decode(expr.expr, encoding.expr))
 
@@ -742,6 +751,7 @@ def digest(value: Expr, method: Expr | str) -> Expr:
         >>> len(result.collect_column("d")[0].as_py()) > 0
         True
     """
+    _warn_if_expr_for_literal_arg(method, "digest", "method")
     method = coerce_to_expr(method)
     return Expr(f.digest(value.expr, method.expr))
 
@@ -3096,6 +3106,7 @@ def arrow_cast(expr: Expr, data_type: Expr | str | pa.DataType) -> Expr:
         >>> result.collect_column("c")[0].as_py()
         1.0
     """
+    _warn_if_expr_for_literal_arg(data_type, "arrow_cast", "data_type")
     if isinstance(data_type, pa.DataType):
         return expr.cast(data_type)
     if isinstance(data_type, str):
@@ -3128,6 +3139,7 @@ def arrow_try_cast(expr: Expr, data_type: Expr | str | pa.DataType) -> Expr:
         >>> result.collect_column("c")[0].as_py() is None
         True
     """
+    _warn_if_expr_for_literal_arg(data_type, "arrow_try_cast", "data_type")
     if isinstance(data_type, pa.DataType):
         return expr.try_cast(data_type)
     if isinstance(data_type, str):
@@ -3235,6 +3247,7 @@ def arrow_metadata(expr: Expr, key: Expr | str | None = None) -> Expr:
     """
     if key is None:
         return Expr(f.arrow_metadata(expr.expr))
+    _warn_if_expr_for_literal_arg(key, "arrow_metadata", "key")
     if isinstance(key, str):
         key = Expr.string_literal(key)
     return Expr(f.arrow_metadata(expr.expr, key.expr))

--- a/python/tests/test_functions.py
+++ b/python/tests/test_functions.py
@@ -1014,7 +1014,7 @@ def test_string_functions(df, function, expected_result):
 
 def test_hash_functions(df):
     exprs = [
-        f.digest(column("a"), literal(m))
+        f.digest(column("a"), m)
         for m in (
             "md5",
             "sha224",
@@ -1602,12 +1602,10 @@ def test_regr_funcs_df(func, expected):
 
 def test_binary_string_functions(df):
     df = df.select(
-        f.encode(column("a").cast(pa.string()), literal("base64").cast(pa.string())),
+        f.encode(column("a").cast(pa.string()), "base64"),
         f.decode(
-            f.encode(
-                column("a").cast(pa.string()), literal("base64").cast(pa.string())
-            ),
-            literal("base64").cast(pa.string()),
+            f.encode(column("a").cast(pa.string()), "base64"),
+            "base64",
         ),
     )
     result = df.collect()

--- a/python/tests/test_functions.py
+++ b/python/tests/test_functions.py
@@ -2399,7 +2399,10 @@ class TestPythonicNativeTypes:
     def test_literal_only_expr_args_warn_deprecated(self, func, arg_name, expr):
         with pytest.warns(
             DeprecationWarning,
-            match=rf"Passing Expr for {func.__name__}\(\) argument '{arg_name}' is deprecated",
+            match=(
+                rf"Passing Expr for {func.__name__}\(\) argument "
+                rf"'{arg_name}' is deprecated"
+            ),
         ):
             result = expr()
         assert result is not None

--- a/python/tests/test_functions.py
+++ b/python/tests/test_functions.py
@@ -2355,6 +2355,65 @@ class TestPythonicNativeTypes:
         ).collect()
         assert result[0].column(0)[0].as_py() == "aX bX cX"
 
+    @pytest.mark.parametrize(
+        ("func", "arg_name", "expr"),
+        [
+            pytest.param(
+                f.encode,
+                "encoding",
+                lambda: f.encode(column("a"), literal("base64")),
+                id="encode-encoding",
+            ),
+            pytest.param(
+                f.decode,
+                "encoding",
+                lambda: f.decode(column("a"), literal("base64")),
+                id="decode-encoding",
+            ),
+            pytest.param(
+                f.digest,
+                "method",
+                lambda: f.digest(column("a"), literal("sha256")),
+                id="digest-method",
+            ),
+            pytest.param(
+                f.arrow_cast,
+                "data_type",
+                lambda: f.arrow_cast(column("a"), literal("Float64")),
+                id="arrow-cast-data-type",
+            ),
+            pytest.param(
+                f.arrow_try_cast,
+                "data_type",
+                lambda: f.arrow_try_cast(column("a"), literal("Float64")),
+                id="arrow-try-cast-data-type",
+            ),
+            pytest.param(
+                f.arrow_metadata,
+                "key",
+                lambda: f.arrow_metadata(column("a"), literal("k")),
+                id="arrow-metadata-key",
+            ),
+        ],
+    )
+    def test_literal_only_expr_args_warn_deprecated(self, func, arg_name, expr):
+        with pytest.warns(
+            DeprecationWarning,
+            match=rf"Passing Expr for {func.__name__}\(\) argument '{arg_name}' is deprecated",
+        ):
+            result = expr()
+        assert result is not None
+
+    def test_literal_only_native_args_do_not_warn(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            assert f.encode(column("a"), "base64") is not None
+            assert f.decode(column("a"), "base64") is not None
+            assert f.digest(column("a"), "sha256") is not None
+            assert f.arrow_cast(column("a"), "Float64") is not None
+            assert f.arrow_try_cast(column("a"), pa.float64()) is not None
+            assert f.arrow_metadata(column("a"), "k") is not None
+
     def test_backward_compat_with_lit(self):
         """Verify that existing code using lit() still works."""
         ctx = SessionContext()


### PR DESCRIPTION
## Which issue does this PR close?

* Part of #1496

## Rationale for this change

As part of the audit of `Expr | literal` function arguments, this change targets a set of arguments that act as control/configuration parameters rather than row-varying data expressions. These arguments are intended to be provided as Python literals (for example, encoding names, digest methods, data type specifiers, and metadata keys).

To prepare for future API cleanup while preserving compatibility, passing an `Expr` to these arguments now emits a `DeprecationWarning` but continues to work.

## What changes are included in this PR?

* Added a reusable helper, `_warn_if_expr_for_literal_arg`, that emits a deprecation warning when an `Expr` is supplied to a confirmed literal-only argument.
* Added deprecation warnings for the following function arguments:

  * `encode(..., encoding=...)`
  * `decode(..., encoding=...)`
  * `digest(..., method=...)`
  * `arrow_cast(..., data_type=...)`
  * `arrow_try_cast(..., data_type=...)`
  * `arrow_metadata(..., key=...)`
* Preserved existing behavior by continuing to coerce these values to expressions after warning.
* Added tests covering both warning and non-warning cases.

## Are these changes tested?

Yes.

Added tests in `python/tests/test_functions.py` that verify:

* Passing `literal(...)` / `Expr` values to the audited literal-only arguments emits a `DeprecationWarning`.
* Passing native Python literal values does **not** emit a `DeprecationWarning`.
* Coverage includes:

  * `encode`
  * `decode`
  * `digest`
  * `arrow_cast`
  * `arrow_try_cast`
  * `arrow_metadata`



## Are there any user-facing changes?

Yes.

Users will now receive a `DeprecationWarning` when passing an `Expr` to the following literal-only arguments:

* `encode(..., encoding=...)`
* `decode(..., encoding=...)`
* `digest(..., method=...)`
* `arrow_cast(..., data_type=...)`
* `arrow_try_cast(..., data_type=...)`
* `arrow_metadata(..., key=...)`

Existing behavior is otherwise unchanged, and Python literal inputs remain fully supported without warnings.

## LLM-generated code disclosure

This PR includes code, comments generated with assistance from LLM. All LLM-generated content has been manually reviewed.
