### PR TITLE
chore: remove 3.13 freethreaded builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,7 +140,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-tag: ["abi3", "3.13t", "3.14t"]
+        python-tag: ["abi3", "3.14t"]
     steps:
       - uses: actions/checkout@v6
 
@@ -219,7 +219,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-tag: ["abi3", "3.13t", "3.14t"]
+        python-tag: ["abi3", "3.14t"]
     steps:
       - uses: actions/checkout@v6
 
@@ -282,7 +282,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, windows-latest]
-        python-tag: ["abi3", "3.13t", "3.14t"]
+        python-tag: ["abi3", "3.14t"]
     steps:
       - uses: actions/checkout@v6
 
@@ -364,7 +364,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-tag: ["abi3", "3.13t", "3.14t"]
+        python-tag: ["abi3", "3.14t"]
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,6 @@ jobs:
           - { python-version: "3.13", wheel-tag: "abi3", freethreaded: false }
           - { python-version: "3.14", wheel-tag: "abi3", freethreaded: false }
           # Free-threaded builds — one wheel per interpreter.
-          - { python-version: "3.13t", wheel-tag: "3.13t", freethreaded: true }
           - { python-version: "3.14t", wheel-tag: "3.14t", freethreaded: true }
     steps:
       - uses: actions/checkout@v6
@@ -90,7 +89,7 @@ jobs:
           # asked by exact path, so plain `uv sync` (even with an activated
           # venv or --active) re-picks the system 3.12 and recreates .venv.
           # Targeting .venv/bin/python keeps sync and pip install in the
-          # same 3.13t/3.14t environment as the cp313t/cp314t wheel.
+          # same 3.14t environment as the cp314t wheel.
           uv venv --python "${{ steps.setup-python.outputs.python-path }}"
           VENV_PY="$PWD/.venv/bin/python"
           uv sync --python "$VENV_PY" --dev --no-install-package datafusion


### PR DESCRIPTION
# Which issue does this PR close?

None.

 # Rationale for this change

The experimental freethreaded python in 3.13 has been reported as having difficulty and support for 3.13 as dropped in PyO3, so before we release this version we may as well drop 3.13t.

https://py-free-threading.github.io/ci/#building-free-threaded-wheels-with-cibuildwheel

https://github.com/PyO3/pyo3/releases/tag/v0.29.0

# What changes are included in this PR?

Remove 3.13 free theaded build.

# Are there any user-facing changes?

None