### PR TITLE
Fix non-portable `find -iname` in verify-release-candidate.sh

### DIFF
--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -153,7 +153,7 @@ test_source_distribution() {
   #TODO: we should really run tests here as well
   #python3 -m pytest
 
-  if ( find -iname 'Cargo.toml' | xargs grep SNAPSHOT ); then
+  if ( find . -iname 'Cargo.toml' | xargs grep SNAPSHOT ); then
     echo "Cargo.toml version should not contain SNAPSHOT for releases"
     exit 1
   fi


### PR DESCRIPTION
# Which issue does this PR close?

No separate issue filed; this is a small portability fix to the release verification script.

# Rationale for this change

The SNAPSHOT-version guard in `verify-release-candidate.sh` runs:

```sh
if ( find -iname 'Cargo.toml' | xargs grep SNAPSHOT ); then
```

`find` is invoked without a starting path. GNU find (Linux) tolerates this and treats the current directory as the start, but BSD find (macOS) rejects it:

```
find: illegal option -- i
```

When that happens, `find` prints the usage error and produces no output, so the piped `xargs grep SNAPSHOT` receives nothing and exits non-zero. The `if (...)` therefore evaluates false and the script continues — meaning **the SNAPSHOT check is silently skipped on macOS** rather than actually running. A release verifier on macOS would get a passing run without this safety check ever executing.

This surfaced while verifying the 54.0.0 RC on macOS.

# What changes are included in this PR?

Add an explicit `.` starting path:

```sh
if ( find . -iname 'Cargo.toml' | xargs grep SNAPSHOT ); then
```

This is accepted by both GNU and BSD find, so the SNAPSHOT check runs correctly on Linux and macOS.

# Are there any user-facing changes?

No. This only affects the release-candidate verification script used by maintainers.

This pull request and its description were written by Isaac.