### PR TITLE
fix: clone parquet-testing into `parquet` in verify-release-candidate.sh

### DIFF
--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -132,7 +132,7 @@ test_source_distribution() {
 
   # Clone testing repositories into the expected location
   git clone https://github.com/apache/arrow-testing.git testing
-  git clone https://github.com/apache/parquet-testing.git parquet-testing
+  git clone https://github.com/apache/parquet-testing.git parquet
 
   python3 -m venv .venv
   if [ -x ".venv/bin/python" ]; then


### PR DESCRIPTION
# Which issue does this PR close?

<!-- No separate issue filed; this is a trivial fix to release tooling. -->

No separate issue. This is a one-line fix to the release verification script, found while manually running the release verification process for 54.0.0-rc2.

# Rationale for this change

`dev/release/verify-release-candidate.sh` clones the parquet-testing repository into a directory named `parquet-testing`:

```bash
git clone https://github.com/apache/parquet-testing.git parquet-testing
```

However, the git submodule path declared in `.gitmodules` is `parquet`:

```toml
[submodule "parquet"]
path = parquet
url = https://github.com/apache/parquet-testing.git
```

and the parquet-based tests resolve their data relative to `parquet/data/...`, for example:

- `python/tests/test_io.py`: `read_parquet(path="parquet/data/alltypes_plain.parquet")`
- `python/tests/test_store.py`: `file://{Path.cwd()}/parquet/data/alltypes_plain.parquet`
- `python/tests/test_context.py`: `parquet/data/alltypes_plain.parquet`

The arrow-testing clone on the line immediately above already correctly uses its submodule path (`testing`), so the parquet line is an inconsistency.

This is currently **latent**: the script's `python3 -m pytest` invocation is commented out (`#TODO: we should really run tests here as well`), so the wrong directory is never exercised today. If/when the test run is enabled during release verification, the parquet-reading tests would fail with *"No files found ... Cannot infer schema from an empty location"*. Fixing the clone path is a prerequisite for enabling those tests.

# What changes are included in this PR?

- Clone parquet-testing into `parquet` (instead of `parquet-testing`) so it matches the `.gitmodules` submodule path and the paths the test suite expects.

# Are there any user-facing changes?

No. This only affects the release verification tooling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pj5DVU7MaammM2nfHh1ZRG