### PR TITLE
docs: fix bootstrap instructions in contributor guide

### DIFF
--- a/docs/source/contributor-guide/introduction.md
+++ b/docs/source/contributor-guide/introduction.md
@@ -66,7 +66,7 @@ Whenever rust code changes (your changes or via `git pull`):
 
 ```shell
 # make sure you activate the venv using "source .venv/bin/activate" first
-maturin develop -uv
+maturin develop --uv
 python -m pytest
 ```
 

--- a/docs/source/contributor-guide/introduction.md
+++ b/docs/source/contributor-guide/introduction.md
@@ -47,6 +47,8 @@ Bootstrap:
 ```shell
 # fetch this repo
 git clone git@github.com:apache/datafusion-python.git
+# cd to the repo root
+cd datafusion-python/
 # create the virtual environment
 uv sync --dev --no-install-package datafusion
 # activate the environment


### PR DESCRIPTION
# Which issue does this PR close?

N/A, trivial doc fix.

# Rationale for this change

The bootstrap instructions in the contributor guide are missing the `cd` step and have a `-uv` -> `--uv` typo. `README.md` already has both correct.

# What changes are included in this PR?

Fix both in `docs/source/contributor-guide/introduction.md`.

# Are there any user-facing changes?

No.