### PR TITLE
fix: no panic on empty partition in register_record_batches

### DIFF
--- a/crates/core/src/context.rs
+++ b/crates/core/src/context.rs
@@ -837,8 +837,7 @@ impl PySessionContext {
         let schema = partitions
             .0
             .iter()
-            .flatten()
-            .next()
+            .find_map(|partition| partition.first())
             .ok_or_else(|| {
                 PyValueError::new_err(
                     "Cannot register record batches without a schema: the \

--- a/crates/core/src/context.rs
+++ b/crates/core/src/context.rs
@@ -832,7 +832,20 @@ impl PySessionContext {
         name: &str,
         partitions: PyArrowType<Vec<Vec<RecordBatch>>>,
     ) -> PyDataFusionResult<()> {
-        let schema = partitions.0[0][0].schema();
+        // Take the schema from the first available batch; error instead of
+        // panicking when the partitions hold no batches.
+        let schema = partitions
+            .0
+            .iter()
+            .flatten()
+            .next()
+            .ok_or_else(|| {
+                PyValueError::new_err(
+                    "Cannot register record batches without a schema: the \
+                     provided partitions contain no record batches.",
+                )
+            })?
+            .schema();
         let table = MemTable::try_new(schema, partitions.0)?;
         self.ctx.register_table(name, Arc::new(table))?;
         Ok(())

--- a/python/tests/test_context.py
+++ b/python/tests/test_context.py
@@ -116,6 +116,18 @@ def test_register_record_batches(ctx):
     assert result[0].column(1) == pa.array([-3, -3, -3])
 
 
+def test_register_record_batches_empty(ctx):
+    # A partition list with no record batches carries no schema, so this used to
+    # panic on unchecked `[0][0]` indexing. It should now raise a clear error.
+    with pytest.raises(ValueError, match="no record batches"):
+        ctx.register_record_batches("t", [[]])
+
+    # The schema is still recovered from a later non-empty partition.
+    batch = pa.RecordBatch.from_arrays([pa.array([1, 2, 3])], names=["a"])
+    ctx.register_record_batches("t2", [[], [batch]])
+    assert ctx.sql("SELECT a FROM t2").collect()[0].column(0) == pa.array([1, 2, 3])
+
+
 def test_create_dataframe_registers_unique_table_name(ctx):
     # create a RecordBatch and register it as memtable
     batch = pa.RecordBatch.from_arrays(

--- a/python/tests/test_context.py
+++ b/python/tests/test_context.py
@@ -122,6 +122,10 @@ def test_register_record_batches_empty(ctx):
     with pytest.raises(ValueError, match="no record batches"):
         ctx.register_record_batches("t", [[]])
 
+    # An empty outer partition list carries no schema either, and raises the same error.
+    with pytest.raises(ValueError, match="no record batches"):
+        ctx.register_record_batches("t", [])
+
     # The schema is still recovered from a later non-empty partition.
     batch = pa.RecordBatch.from_arrays([pa.array([1, 2, 3])], names=["a"])
     ctx.register_record_batches("t2", [[], [batch]])


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1626 .

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
`register_record_batches` read the schema via unchecked `partitions.0[0][0]`, which panics when a partition contains no record batches (e.g. the batches of an empty pyarrow table, whose `to_batches()` returns `[]`).


# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Take the schema from the first available batch across all partitions and return a clear error when there is none, mirroring the empty-table handling added for `from_arrow_table` in #613. A non-empty later partition now also works instead of panicking on an empty leading one.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
register_record_batches now raises a catchable Python Exception on empty input instead of aborting with a Rust panic

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->