### PR TITLE
Update pinned Rust toolchain action revision

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,10 +48,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
-        with:
-          toolchain: "nightly"
-          components: rustfmt
+        run: rustup toolchain install nightly --profile minimal --component rustfmt
 
       - name: Cache Cargo
         uses: Swatinem/rust-cache@v2
@@ -152,7 +149,9 @@ jobs:
           path: .
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
 
       - name: Cache Cargo
         uses: Swatinem/rust-cache@v2
@@ -231,7 +230,9 @@ jobs:
           path: .
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
 
       - name: Cache Cargo
         uses: Swatinem/rust-cache@v2
@@ -286,7 +287,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+      - name: Setup Rust
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
 
       - run: rm LICENSE.txt
       - name: Download LICENSE.txt
@@ -368,7 +372,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+      - name: Setup Rust
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
 
       - run: rm LICENSE.txt
       - name: Download LICENSE.txt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30
         with:
           toolchain: "nightly"
           components: rustfmt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,10 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Setup Rust
-        run: rustup toolchain install nightly --profile minimal --component rustfmt
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+        with:
+          toolchain: "nightly"
+          components: rustfmt
 
       - name: Cache Cargo
         uses: Swatinem/rust-cache@v2
@@ -149,9 +152,7 @@ jobs:
           path: .
 
       - name: Setup Rust
-        run: |
-          rustup toolchain install stable --profile minimal
-          rustup default stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
 
       - name: Cache Cargo
         uses: Swatinem/rust-cache@v2
@@ -230,9 +231,7 @@ jobs:
           path: .
 
       - name: Setup Rust
-        run: |
-          rustup toolchain install stable --profile minimal
-          rustup default stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
 
       - name: Cache Cargo
         uses: Swatinem/rust-cache@v2
@@ -287,10 +286,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Setup Rust
-        run: |
-          rustup toolchain install stable --profile minimal
-          rustup default stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
 
       - run: rm LICENSE.txt
       - name: Download LICENSE.txt
@@ -372,10 +368,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Setup Rust
-        run: |
-          rustup toolchain install stable --profile minimal
-          rustup default stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
 
       - run: rm LICENSE.txt
       - name: Download LICENSE.txt


### PR DESCRIPTION
## Which issue does this PR close?

* Closes #1634.

## Rationale for this change

Update the pinned `dtolnay/rust-toolchain` action revision used by the build workflow.

## What changes are included in this PR?

* Updates `dtolnay/rust-toolchain` from commit `29eef336d9b2848a0b548edc03f92a220660cdb8` to `4be7066ada62dd38de10e7b70166bc74ed198c30`.
* Keeps the existing nightly Rust toolchain and `rustfmt` component configuration unchanged.

## Are these changes tested?

No tests are included in this patch. The change only updates the pinned revision of a GitHub Actions dependency.

## Are there any user-facing changes?

No user-facing changes.

## LLM-generated code disclosure

This PR includes code and comments generated with assistance from an LLM. All LLM-generated content has been manually reviewed.
