### PR TITLE
fix: tighten scalar UDF return type hints

### DIFF
--- a/python/datafusion/user_defined.py
+++ b/python/datafusion/user_defined.py
@@ -33,7 +33,7 @@ from datafusion.expr import Expr
 if TYPE_CHECKING:
     from _typeshed import CapsuleType as _PyCapsule
 
-    _R = TypeVar("_R", bound=pa.DataType)
+    _R = TypeVar("_R", bound=pa.Array)
     from collections.abc import Callable, Sequence
 
 
@@ -125,7 +125,7 @@ class ScalarUDF:
         name: str,
         func: Callable[..., _R],
         input_fields: list[pa.Field],
-        return_field: _R,
+        return_field: pa.Field,
         volatility: Volatility | str,
     ) -> None:
         """Instantiate a scalar user-defined function (UDF).
@@ -264,7 +264,7 @@ class ScalarUDF:
 
         def _decorator(
             input_fields: Sequence[pa.DataType | pa.Field] | pa.DataType | pa.Field,
-            return_field: _R,
+            return_field: pa.DataType | pa.Field,
             volatility: Volatility | str,
             name: str | None = None,
         ) -> Callable:

--- a/python/datafusion/user_defined.py
+++ b/python/datafusion/user_defined.py
@@ -202,7 +202,8 @@ class ScalarUDF:
             input_fields (list[pa.Field | pa.DataType]): The data types or Fields
                 of the arguments to ``func``. This list must be of the same length
                 as the number of arguments.
-            return_field (_R): The field of the return value from the function.
+            return_field (pa.DataType | pa.Field): The field of the return value
+                from the function.
             volatility (Volatility | str): See `Volatility` for allowed values.
             name (Optional[str]): A descriptive name for the function.
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1507.

# Rationale for this change

The scalar UDF helper currently uses the same type variable for the Python callable return value and the declared Arrow return field. Those are different concepts: the callable returns Arrow arrays, while `return_field` can be an Arrow data type or field used to declare the UDF output.

Keeping those hints separate makes the public wrapper easier to use from type checkers and avoids implying that callers should pass an array object as the return field.

# What changes are included in this PR?

This PR tightens the scalar UDF annotations in `python/datafusion/user_defined.py`:

- the callable return type is bounded to `pa.Array`
- the scalar UDF constructor accepts `return_field: pa.Field`
- the decorator form accepts `return_field: pa.DataType | pa.Field`

# Are there any user-facing changes?

No runtime behavior changes. This only updates Python type hints for the scalar UDF wrapper.

Validation run locally:

- `uvx ruff@0.15.1 check python/datafusion/user_defined.py` - passed
- `uvx ruff@0.15.1 format --check python/datafusion/user_defined.py` - passed
- `git diff --check origin/main...HEAD` - passed