### PR TITLE
Add is_nan aliases

### DIFF
--- a/python/datafusion/expr.py
+++ b/python/datafusion/expr.py
@@ -1226,6 +1226,12 @@ class Expr:  # noqa: PLW1641
 
         return F.isnan(self)
 
+    def is_nan(self) -> Expr:
+        """Returns true if a given number is +NaN or -NaN otherwise returns false."""
+        from . import functions as F
+
+        return F.is_nan(self)
+
     def degrees(self) -> Expr:
         """Converts the argument from radians to degrees."""
         from . import functions as F

--- a/python/datafusion/functions/__init__.py
+++ b/python/datafusion/functions/__init__.py
@@ -217,6 +217,7 @@ __all__ = [
     "initcap",
     "inner_product",
     "instr",
+    "is_nan",
     "isnan",
     "iszero",
     "lag",
@@ -411,6 +412,11 @@ def isnan(expr: Expr) -> Expr:
         True
     """
     return Expr(f.isnan(expr.expr))
+
+
+def is_nan(expr: Expr) -> Expr:
+    """Returns true if a given number is +NaN or -NaN otherwise returns false."""
+    return isnan(expr)
 
 
 def nullif(expr1: Expr, expr2: Expr) -> Expr:

--- a/python/datafusion/functions/__init__.py
+++ b/python/datafusion/functions/__init__.py
@@ -415,7 +415,7 @@ def isnan(expr: Expr) -> Expr:
 
 
 def is_nan(expr: Expr) -> Expr:
-    """Returns true if a given number is +NaN or -NaN otherwise returns false."""
+    """Alias for :func:`isnan`."""
     return isnan(expr)
 
 

--- a/python/tests/test_expr.py
+++ b/python/tests/test_expr.py
@@ -501,6 +501,11 @@ def test_alias_with_metadata(df):
             id="isnan",
         ),
         pytest.param(
+            col("e").is_nan(),
+            pa.array([False, True, False, None], type=pa.bool_()),
+            id="is_nan",
+        ),
+        pytest.param(
             functions.round(col("a").degrees(), lit(4)),
             pa.array([-42.9718, 28.6479, 0.0, None], type=pa.float64()),
             id="degrees",

--- a/python/tests/test_functions.py
+++ b/python/tests/test_functions.py
@@ -215,6 +215,15 @@ def test_math_functions():
     )
 
 
+def test_is_nan_alias():
+    ctx = SessionContext()
+    df = ctx.from_pydict({"value": [1.0, np.nan, None]})
+
+    result = df.select(f.is_nan(column("value")).alias("is_nan")).to_pydict()
+
+    assert result == {"is_nan": [False, True, None]}
+
+
 def py_indexof(arr, v):
     try:
         return arr.index(v) + 1


### PR DESCRIPTION
Closes #1235

# Rationale for this change

The Python API currently exposes `is_null()` with snake_case naming, but the NaN check is only available as `isnan()`. Adding `is_nan()` gives users a casing-consistent spelling while preserving the existing `isnan()` API.

# What changes are included in this PR?

This adds `datafusion.functions.is_nan(...)` as an alias for `isnan(...)` and adds `Expr.is_nan()` as the corresponding expression method. Existing `isnan()` behavior is unchanged.

The PR also adds coverage for both the function-level alias and the expression method.

# Are there any user-facing changes?

Yes. Users can now call `functions.is_nan(col(...))` and `col(...).is_nan()` in addition to the existing `isnan` spelling. This is additive and does not remove or deprecate the current API.

# Testing

```bash
uvx pre-commit run --files python/datafusion/functions/__init__.py python/datafusion/expr.py python/tests/test_functions.py python/tests/test_expr.py
```

Result: passed.

I also ran a WSL canary against the published `datafusion==54.0.0` wheel with the modified wrapper files overlaid:

```text
is_nan aliases match isnan output: [False, True, None]
```

Note: a full Windows `uv run pytest` is blocked on this machine because building `nanoarrow==0.8.0` requires a local C/C++ compiler.
